### PR TITLE
Make ArticlePrice.Tax an optional pointer field

### DIFF
--- a/bmecat12/article.go
+++ b/bmecat12/article.go
@@ -193,7 +193,7 @@ type ArticlePrice struct {
 	Type       string   `xml:"price_type,attr,omitempty"`
 	Amount     float64  `xml:"PRICE_AMOUNT"`
 	Currency   string   `xml:"PRICE_CURRENCY,omitempty"`
-	Tax        float64  `xml:"TAX,omitempty"`
+	Tax        *float64 `xml:"TAX,omitempty"`
 	Factor     float64  `xml:"PRICE_FACTOR,omitempty"`
 	LowerBound float64  `xml:"LOWER_BOUND,omitempty"`
 	Territory  []string `xml:"TERRITORY,omitempty"`

--- a/bmecat12/writer_test.go
+++ b/bmecat12/writer_test.go
@@ -15,6 +15,9 @@ import (
 // intp returns a pointer to the given int, for use in optional fields.
 func intp(v int) *int { return &v }
 
+// float64p returns a pointer to the given float64, for use in optional fields.
+func float64p(v float64) *float64 { return &v }
+
 var (
 	testHeader = &bmecat12.Header{
 		GeneratorInfo: "BMEcat Generator",
@@ -224,7 +227,7 @@ func TestWriteNewCatalog(t *testing.T) {
 							Type:       bmecat12.ArticlePriceTypeNetCustomer,
 							Amount:     1499.50,
 							Currency:   "EUR",
-							Tax:        0.19,
+							Tax:        float64p(0.19),
 							Factor:     1.0,
 							LowerBound: 1,
 							Territory:  []string{"DE", "AT"},
@@ -233,7 +236,7 @@ func TestWriteNewCatalog(t *testing.T) {
 							Type:       bmecat12.ArticlePriceTypeNetCustomer,
 							Amount:     1300.90,
 							Currency:   "EUR",
-							Tax:        0.19,
+							Tax:        float64p(0.19),
 							Factor:     1.0,
 							LowerBound: 100,
 							Territory:  []string{"DE", "AT"},
@@ -389,7 +392,7 @@ func TestWriteUpdateProducts(t *testing.T) {
 							Type:       bmecat12.ArticlePriceTypeNetCustomer,
 							Amount:     1499.50,
 							Currency:   "EUR",
-							Tax:        0.19,
+							Tax:        float64p(0.19),
 							Factor:     1.0,
 							LowerBound: 1,
 							Territory:  []string{"DE", "AT"},
@@ -398,7 +401,7 @@ func TestWriteUpdateProducts(t *testing.T) {
 							Type:       bmecat12.ArticlePriceTypeNetCustomer,
 							Amount:     1300.90,
 							Currency:   "EUR",
-							Tax:        0.19,
+							Tax:        float64p(0.19),
 							Factor:     1.0,
 							LowerBound: 100,
 							Territory:  []string{"DE", "AT"},
@@ -476,7 +479,7 @@ func TestWriteUpdatePrices(t *testing.T) {
 							Type:       bmecat12.ArticlePriceTypeNetCustomer,
 							Amount:     1499.50,
 							Currency:   "EUR",
-							Tax:        0.19,
+							Tax:        float64p(0.19),
 							Factor:     1.0,
 							LowerBound: 1,
 							Territory:  []string{"DE", "AT"},
@@ -485,7 +488,7 @@ func TestWriteUpdatePrices(t *testing.T) {
 							Type:       bmecat12.ArticlePriceTypeNetCustomer,
 							Amount:     1300.90,
 							Currency:   "EUR",
-							Tax:        0.19,
+							Tax:        float64p(0.19),
 							Factor:     1.0,
 							LowerBound: 100,
 							Territory:  []string{"DE", "AT"},
@@ -588,7 +591,7 @@ func TestWriteNewCatalogWithBlankClassificationSystem(t *testing.T) {
 							Type:       bmecat12.ArticlePriceTypeNetCustomer,
 							Amount:     1499.50,
 							Currency:   "EUR",
-							Tax:        0.19,
+							Tax:        float64p(0.19),
 							Factor:     1.0,
 							LowerBound: 1,
 							Territory:  []string{"DE", "AT"},
@@ -597,7 +600,7 @@ func TestWriteNewCatalogWithBlankClassificationSystem(t *testing.T) {
 							Type:       bmecat12.ArticlePriceTypeNetCustomer,
 							Amount:     1300.90,
 							Currency:   "EUR",
-							Tax:        0.19,
+							Tax:        float64p(0.19),
 							Factor:     1.0,
 							LowerBound: 100,
 							Territory:  []string{"DE", "AT"},


### PR DESCRIPTION
## Summary

`ArticlePrice.Tax` was typed `float64`, which (with `omitempty`) cannot distinguish an absent `TAX` from an explicit `0`. `TAX` is optional in BMEcat, so this changes the type to `*float64`: `nil` represents absent, and a pointer-to-`0` still emits `<TAX>0</TAX>`.

Unlike `DELIVERY_TIME` (whole days, `*int` via #9), `TAX` is a tax rate (e.g. `0.19`) and is genuinely fractional, so `*float64` is the correct type.

## Changes

- `bmecat12/article.go`: `Tax float64` → `Tax *float64`
- `bmecat12/writer_test.go`: add a `float64p` helper; fixtures use `float64p(0.19)`

Golden fixtures are unchanged: `0.19` is non-zero, so the emitted XML is identical.

## Notes

This completes #6 (the `DeliveryTime` half landed in #9).

Closes #10
Refs #6