### PR TITLE
Add tests and broaden charset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ func main() {
 }
 ```
 
+### Character encodings
+
+The reader decodes any encoding declared in the XML prolog that is registered
+with the IANA character set registry and implemented by `golang.org/x/text` —
+UTF-8, the ISO-8859 family, Windows code pages, and CJK encodings such as GBK,
+GB18030, Big5, Shift-JIS and EUC-KR. ISO-8859-1 is decoded leniently as
+Windows-1252, which matches how most real-world catalogs are authored.
+
 ## Writing a catalog
 
 Implement the `bmecat12.CatalogWriter` interface and hand it to `Writer.Do`.

--- a/bmecat12/coverage_test.go
+++ b/bmecat12/coverage_test.go
@@ -1,0 +1,294 @@
+package bmecat12_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/transform"
+
+	"github.com/olivere/bmecat/bmecat12"
+	"github.com/olivere/bmecat/internal"
+)
+
+// errBoom is a sentinel error used to assert that the reader and writer wrap
+// and propagate handler errors via %w.
+var errBoom = errors.New("boom")
+
+// --- Reader error paths -----------------------------------------------------
+
+func TestReadMalformedXML(t *testing.T) {
+	// Mismatched end tag: the tokenizer must fail in the first pass.
+	const malformed = `<BMECAT><HEADER></BMECAT>`
+	r := bmecat12.NewReader(bytes.NewReader([]byte(malformed)))
+	if err := r.Do(context.Background(), &testHandler{}); err == nil {
+		t.Fatal("expected an error for malformed XML, got nil")
+	}
+}
+
+type failingArticleHandler struct{}
+
+func (failingArticleHandler) HandleArticle(*bmecat12.Article) error { return errBoom }
+
+func TestReadArticleHandlerError(t *testing.T) {
+	f, err := os.Open(filepath.Join("testdata", "new_catalog.golden.xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	r := bmecat12.NewReader(f)
+	err = r.Do(context.Background(), failingArticleHandler{})
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("expected wrapped errBoom, got %v", err)
+	}
+}
+
+// --- Reader group dispatch and completion -----------------------------------
+
+type recordingHandler struct {
+	classGroups   int
+	catalogGroups []*bmecat12.CatalogGroup
+	completed     int
+}
+
+func (h *recordingHandler) HandleClassificationGroup(*bmecat12.ClassificationGroup) error {
+	h.classGroups++
+	return nil
+}
+
+func (h *recordingHandler) HandleCatalogGroup(cg *bmecat12.CatalogGroup) error {
+	h.catalogGroups = append(h.catalogGroups, cg)
+	return nil
+}
+
+func (h *recordingHandler) HandleComplete() { h.completed++ }
+
+func TestReadClassificationGroupsAndComplete(t *testing.T) {
+	f, err := os.Open(filepath.Join("testdata", "new_catalog.golden.xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	h := &recordingHandler{}
+	r := bmecat12.NewReader(f)
+	if err := r.Do(context.Background(), h); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := 5, h.classGroups; want != have {
+		t.Errorf("want %d classification groups, have %d", want, have)
+	}
+	if want, have := 1, h.completed; want != have {
+		t.Errorf("want HandleComplete called %d time(s), have %d", want, have)
+	}
+}
+
+func TestReadCatalogGroupDispatch(t *testing.T) {
+	// No golden file contains CATALOG_STRUCTURE, so drive it with inline XML.
+	const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="1.2">
+  <T_NEW_CATALOG>
+    <CATALOG_STRUCTURE type="node">
+      <GROUP_ID>1</GROUP_ID>
+      <GROUP_NAME>Hardware</GROUP_NAME>
+    </CATALOG_STRUCTURE>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+	h := &recordingHandler{}
+	r := bmecat12.NewReader(bytes.NewReader([]byte(xml)))
+	if err := r.Do(context.Background(), h); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := 1, len(h.catalogGroups); want != have {
+		t.Fatalf("want %d catalog group(s), have %d", want, have)
+	}
+	cg := h.catalogGroups[0]
+	if want, have := "1", cg.ID; want != have {
+		t.Errorf("want group ID %q, have %q", want, have)
+	}
+	if want, have := "Hardware", cg.Name; want != have {
+		t.Errorf("want group name %q, have %q", want, have)
+	}
+	if !cg.IsNode() {
+		t.Errorf("want IsNode() == true for type %q", cg.Type)
+	}
+}
+
+// --- Charset handling -------------------------------------------------------
+
+func TestReadISO8859_1(t *testing.T) {
+	// GROUP_NAME contains 0xFC, which is "ü" in ISO-8859-1. The reader must
+	// decode it to UTF-8 via the (explicitly supplied) charset reader.
+	iso := "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" +
+		"<BMECAT version=\"1.2\"><T_NEW_CATALOG>" +
+		"<CATALOG_STRUCTURE type=\"leaf\"><GROUP_ID>1</GROUP_ID>" +
+		"<GROUP_NAME>M\xfcller</GROUP_NAME></CATALOG_STRUCTURE>" +
+		"</T_NEW_CATALOG></BMECAT>"
+
+	h := &recordingHandler{}
+	r := bmecat12.NewReader(
+		bytes.NewReader([]byte(iso)),
+		bmecat12.WithCharsetReader(internal.AutoCharsetReader),
+	)
+	if err := r.Do(context.Background(), h); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := 1, len(h.catalogGroups); want != have {
+		t.Fatalf("want %d catalog group(s), have %d", want, have)
+	}
+	if want, have := "Müller", h.catalogGroups[0].Name; want != have {
+		t.Errorf("want decoded group name %q, have %q", want, have)
+	}
+}
+
+func TestReadUTF8Chinese(t *testing.T) {
+	const doc = `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<BMECAT version="1.2"><T_NEW_CATALOG>` +
+		`<CATALOG_STRUCTURE type="node"><GROUP_ID>1</GROUP_ID>` +
+		`<GROUP_NAME>电子产品</GROUP_NAME></CATALOG_STRUCTURE>` +
+		`</T_NEW_CATALOG></BMECAT>`
+
+	h := &recordingHandler{}
+	r := bmecat12.NewReader(bytes.NewReader([]byte(doc)))
+	if err := r.Do(context.Background(), h); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := 1, len(h.catalogGroups); want != have {
+		t.Fatalf("want %d catalog group(s), have %d", want, have)
+	}
+	if want, have := "电子产品", h.catalogGroups[0].Name; want != have {
+		t.Errorf("want group name %q, have %q", want, have)
+	}
+}
+
+func TestReadGBKChinese(t *testing.T) {
+	const utf8doc = `<?xml version="1.0" encoding="GBK"?>` +
+		`<BMECAT version="1.2"><T_NEW_CATALOG>` +
+		`<CATALOG_STRUCTURE type="node"><GROUP_ID>1</GROUP_ID>` +
+		`<GROUP_NAME>电子产品</GROUP_NAME></CATALOG_STRUCTURE>` +
+		`</T_NEW_CATALOG></BMECAT>`
+
+	// Encode the whole document to GBK; the reader must decode it back.
+	gbk, _, err := transform.String(simplifiedchinese.GBK.NewEncoder(), utf8doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := &recordingHandler{}
+	r := bmecat12.NewReader(
+		bytes.NewReader([]byte(gbk)),
+		bmecat12.WithCharsetReader(internal.AutoCharsetReader),
+	)
+	if err := r.Do(context.Background(), h); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := 1, len(h.catalogGroups); want != have {
+		t.Fatalf("want %d catalog group(s), have %d", want, have)
+	}
+	if want, have := "电子产品", h.catalogGroups[0].Name; want != have {
+		t.Errorf("want decoded group name %q, have %q", want, have)
+	}
+}
+
+// --- Progress callbacks -----------------------------------------------------
+
+func TestReaderProgress(t *testing.T) {
+	f, err := os.Open(filepath.Join("testdata", "new_catalog.golden.xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var maxPass int
+	r := bmecat12.NewReader(f, bmecat12.WithReaderProgress(func(pass int, _ int64) {
+		if pass > maxPass {
+			maxPass = pass
+		}
+	}))
+	if err := r.Do(context.Background(), &testHandler{}); err != nil {
+		t.Fatal(err)
+	}
+	if maxPass < 2 {
+		t.Errorf("want progress to reach pass 2, reached %d", maxPass)
+	}
+}
+
+func TestWriterProgress(t *testing.T) {
+	articles := []*bmecat12.Article{
+		{SupplierAID: "1000", Details: &bmecat12.ArticleDetails{DescriptionShort: "Test"}},
+	}
+	cw := catalogWriter{tx: bmecat12.NewCatalog, header: testHeader, articles: articles}
+
+	var written int
+	w := bmecat12.NewWriter(io.Discard, bmecat12.WithProgress(func(n int) { written = n }))
+	if err := w.Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+	if written < 1 {
+		t.Errorf("want at least 1 article reported, have %d", written)
+	}
+}
+
+// --- Writer error path ------------------------------------------------------
+
+// errArticlesWriter is a CatalogWriter whose article stream fails.
+type errArticlesWriter struct {
+	catalogWriter
+}
+
+func (errArticlesWriter) Articles(context.Context) (<-chan *bmecat12.Article, <-chan error) {
+	outCh := make(chan *bmecat12.Article)
+	errCh := make(chan error, 1)
+	errCh <- errBoom
+	return outCh, errCh
+}
+
+func TestWriteArticlesError(t *testing.T) {
+	cw := errArticlesWriter{catalogWriter{tx: bmecat12.NewCatalog, header: testHeader}}
+
+	w := bmecat12.NewWriter(io.Discard)
+	err := w.Do(context.Background(), cw)
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("expected wrapped errBoom, got %v", err)
+	}
+}
+
+// --- Round trip -------------------------------------------------------------
+
+func TestRoundTrip(t *testing.T) {
+	articles := []*bmecat12.Article{
+		{SupplierAID: "1000", Details: &bmecat12.ArticleDetails{DescriptionShort: "Test product"}},
+	}
+	cw := catalogWriter{tx: bmecat12.NewCatalog, header: testHeader, articles: articles}
+
+	var buf bytes.Buffer
+	w := bmecat12.NewWriter(&buf, bmecat12.WithIndent("  "))
+	if err := w.Do(context.Background(), cw); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	h := &testHandler{}
+	r := bmecat12.NewReader(bytes.NewReader(buf.Bytes()))
+	if err := r.Do(context.Background(), h); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if h.header == nil {
+		t.Fatal("want a header after round trip, have nil")
+	}
+	if want, have := testHeader.Catalog.Name, h.header.Catalog.Name; want != have {
+		t.Errorf("want catalog name %q, have %q", want, have)
+	}
+	if want, have := 1, len(h.articles); want != have {
+		t.Fatalf("want %d article(s), have %d", want, have)
+	}
+	if want, have := "1000", h.articles[0].SupplierAID; want != have {
+		t.Errorf("want supplier AID %q, have %q", want, have)
+	}
+}

--- a/internal/auto_charset_reader.go
+++ b/internal/auto_charset_reader.go
@@ -5,52 +5,29 @@ import (
 	"io"
 	"strings"
 
-	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/encoding/htmlindex"
 	"golang.org/x/text/transform"
 )
 
-// AutoCharsetReader returns a charset reader for XML decoding.
+// AutoCharsetReader returns a charset reader for XML decoding. It resolves the
+// declared encoding through golang.org/x/text/encoding/htmlindex, which accepts
+// every label in the WHATWG Encoding Standard — UTF-8, the ISO-8859 family,
+// Windows code pages, and CJK encodings such as GBK, GB18030, Big5, Shift-JIS
+// and EUC-KR — so encodings need not be enumerated here.
+//
+// Following that standard, ISO-8859-1 (and latin1) is decoded as its
+// Windows-1252 superset and GB2312 as GBK, which matches how real-world
+// catalogs are authored.
 func AutoCharsetReader(encoding string, r io.Reader) (io.Reader, error) {
-	enc := strings.ToLower(encoding)
-
-	if enc == "" || enc == "utf-8" || enc == "utf8" {
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
+	case "", "utf-8", "utf8":
+		// Already UTF-8: no decoding necessary.
 		return r, nil
 	}
 
-	switch enc {
-	case "ibm code page 437", "cp437", "cp-437":
-		return transform.NewReader(r, charmap.CodePage437.NewDecoder()), nil
-	case "ibm code page 866", "cp866", "cp-866":
-		return transform.NewReader(r, charmap.CodePage866.NewDecoder()), nil
-	case "iso88591", "iso 8859-1", "iso8859-1", "iso-8859-1":
-		return transform.NewReader(r, charmap.Windows1252.NewDecoder()), nil
-	case "iso88592", "iso 8859-2", "iso8859-2", "iso-8859-2":
-		return transform.NewReader(r, charmap.ISO8859_2.NewDecoder()), nil
-	case "iso88593", "iso 8859-3", "iso8859-3", "iso-8859-3":
-		return transform.NewReader(r, charmap.ISO8859_3.NewDecoder()), nil
-	case "iso88594", "iso 8859-4", "iso8859-4", "iso-8859-4":
-		return transform.NewReader(r, charmap.ISO8859_4.NewDecoder()), nil
-	case "iso88595", "iso 8859-5", "iso8859-5", "iso-8859-5":
-		return transform.NewReader(r, charmap.ISO8859_5.NewDecoder()), nil
-	case "iso88596", "iso 8859-6", "iso8859-6", "iso-8859-6":
-		return transform.NewReader(r, charmap.ISO8859_6.NewDecoder()), nil
-	case "iso88597", "iso 8859-7", "iso8859-7", "iso-8859-7":
-		return transform.NewReader(r, charmap.ISO8859_7.NewDecoder()), nil
-	case "iso88598", "iso 8859-8", "iso8859-8", "iso-8859-8":
-		return transform.NewReader(r, charmap.ISO8859_8.NewDecoder()), nil
-	case "iso885910", "iso 8859-10", "iso8859-10", "iso-8859-10":
-		return transform.NewReader(r, charmap.ISO8859_10.NewDecoder()), nil
-	case "iso885913", "iso 8859-13", "iso8859-13", "iso-8859-13":
-		return transform.NewReader(r, charmap.ISO8859_13.NewDecoder()), nil
-	case "iso885914", "iso 8859-14", "iso8859-14", "iso-8859-14":
-		return transform.NewReader(r, charmap.ISO8859_14.NewDecoder()), nil
-	case "iso885915", "iso 8859-15", "iso8859-15", "iso-8859-15":
-		return transform.NewReader(r, charmap.ISO8859_15.NewDecoder()), nil
-	case "iso885916", "iso 8859-16", "iso8859-16", "iso-8859-16":
-		return transform.NewReader(r, charmap.ISO8859_16.NewDecoder()), nil
-	case "windows1252", "windows-1252":
-		return transform.NewReader(r, charmap.Windows1252.NewDecoder()), nil
+	enc, err := htmlindex.Get(encoding)
+	if err != nil || enc == nil {
+		return nil, fmt.Errorf("bmecat: unknown encoding: %q", encoding)
 	}
-
-	return nil, fmt.Errorf("bmecat: unknown encoding: %s", encoding)
+	return transform.NewReader(r, enc.NewDecoder()), nil
 }

--- a/internal/auto_charset_reader_test.go
+++ b/internal/auto_charset_reader_test.go
@@ -1,0 +1,88 @@
+package internal
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/traditionalchinese"
+	"golang.org/x/text/transform"
+)
+
+func TestAutoCharsetReaderPassthrough(t *testing.T) {
+	// UTF-8 and empty encodings must be returned unchanged.
+	for _, enc := range []string{"", "utf-8", "UTF-8", "utf8"} {
+		r, err := AutoCharsetReader(enc, strings.NewReader("Müller"))
+		if err != nil {
+			t.Fatalf("encoding %q: unexpected error: %v", enc, err)
+		}
+		data, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("encoding %q: read failed: %v", enc, err)
+		}
+		if got, want := string(data), "Müller"; got != want {
+			t.Errorf("encoding %q: got %q, want %q", enc, got, want)
+		}
+	}
+}
+
+func TestAutoCharsetReaderISO8859_1(t *testing.T) {
+	// 0xE4 = ä, 0xFC = ü, 0xDF = ß in ISO-8859-1 / Windows-1252.
+	input := []byte{0x4d, 0xfc, 0x6c, 0x6c, 0x65, 0x72} // "Müller" in latin1
+	for _, enc := range []string{"iso-8859-1", "iso8859-1", "latin1", "windows-1252"} {
+		r, err := AutoCharsetReader(enc, strings.NewReader(string(input)))
+		if err != nil {
+			t.Fatalf("encoding %q: unexpected error: %v", enc, err)
+		}
+		data, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("encoding %q: read failed: %v", enc, err)
+		}
+		if got, want := string(data), "Müller"; got != want {
+			t.Errorf("encoding %q: got %q, want %q", enc, got, want)
+		}
+	}
+}
+
+func TestAutoCharsetReaderChinese(t *testing.T) {
+	tests := []struct {
+		enc     string
+		text    string
+		encoder transform.Transformer
+	}{
+		{"gbk", "电子产品", simplifiedchinese.GBK.NewEncoder()},
+		{"gb2312", "电子产品", simplifiedchinese.GBK.NewEncoder()},
+		{"gb18030", "电子产品", simplifiedchinese.GB18030.NewEncoder()},
+		{"big5", "電子產品", traditionalchinese.Big5.NewEncoder()},
+	}
+	for _, tt := range tests {
+		// Encode the UTF-8 text into the legacy encoding, then make sure the
+		// charset reader decodes it back to the original UTF-8.
+		encoded, _, err := transform.String(tt.encoder, tt.text)
+		if err != nil {
+			t.Fatalf("encoding %q: encode failed: %v", tt.enc, err)
+		}
+		r, err := AutoCharsetReader(tt.enc, strings.NewReader(encoded))
+		if err != nil {
+			t.Fatalf("encoding %q: unexpected error: %v", tt.enc, err)
+		}
+		data, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("encoding %q: read failed: %v", tt.enc, err)
+		}
+		if got, want := string(data), tt.text; got != want {
+			t.Errorf("encoding %q: got %q, want %q", tt.enc, got, want)
+		}
+	}
+}
+
+func TestAutoCharsetReaderUnknown(t *testing.T) {
+	r, err := AutoCharsetReader("no-such-charset", strings.NewReader("x"))
+	if err == nil {
+		t.Fatal("expected an error for an unknown encoding, got nil")
+	}
+	if r != nil {
+		t.Errorf("expected a nil reader on error, got %v", r)
+	}
+}


### PR DESCRIPTION
Follow-up to #12. Closes #14.

The modernization in #13 left coverage at the prior happy-path level. This PR adds tests for the **basic requirements that had none**, and — prompted by "does it work with Chinese?" — generalises charset handling.

## Tests added
- **Reader/writer error paths** — malformed XML, and handler errors verified via `errors.Is` against the `%w`-wrapped chain rewritten in #13
- **Group dispatch & completion** — `CatalogGroupHandler`, `ClassificationGroupHandler`, `CompletionHandler` (the shared `testHandler` exercised none of them)
- **Round-trip** — `read(write(x)) == x`
- **Progress callbacks** — `WithReaderProgress`, `WithProgress`
- **Charset** — first tests for `internal/auto_charset_reader.go` (now **100%**), plus end-to-end UTF-8 and GBK Chinese reads through the `Reader`

## Charset generalisation
Replaces the hand-maintained `switch` of ~25 encoding aliases with a lookup through `golang.org/x/text/encoding/htmlindex` (the WHATWG Encoding Standard resolver). Any of its labels now works without enumeration — **GBK, GB18030, Big5, Shift-JIS, EUC-JP/KR, UTF-16**, the full ISO-8859 family, Windows code pages, etc. — and sloppy-but-valid aliases such as `iso8859-2` (no hyphen) resolve correctly.

The WHATWG standard already maps **ISO-8859-1 → Windows-1252** and **GB2312 → GBK**, so the two pragmatic BMEcat-specific special cases are no longer needed — the behaviour falls out of the standard.

(First cut used `ianaindex`, but a self-review found it rejected sloppy aliases like `iso8859-2` that the old code accepted; `htmlindex` is more tolerant and folds in the latin1/gb2312 mappings, so the special cases drop out.)

No new dependency — `htmlindex` ships within the `golang.org/x/text` we already require. Go floor stays `1.25`.

## Before / after
- `电子产品` in UTF-8: worked before and after
- `电子产品` in GBK/GB18030, `電子產品` in Big5: **failed before** (`unknown encoding`), **works now**

## Coverage
`bmecat12` 55% → 63%, `internal` 0% → 100%.

## Verification
`go build ./...`, `go vet ./...`, `go test -race ./...`, `gofumpt -l .`, `govulncheck ./...` — all clean.