### PR TITLE
Add version-neutral bmecat.NewReader facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,68 @@ Go 1.25 or later.
 go get github.com/olivere/bmecat
 ```
 
-## Reading a catalog
+## Reading any version (recommended)
 
-Implement only the handler interfaces you care about — `HeaderHandler`,
-`ArticleHandler`, `CatalogGroupHandler`, `ClassificationGroupHandler` and/or
-`CompletionHandler` — and pass your handler to `Reader.Do`:
+If you ingest catalogs from a mix of suppliers, use the top-level `bmecat`
+package. `bmecat.NewReader` auto-detects the version from the root
+`<BMECAT version="…">` element and normalises both 1.2 and 2005 into a single,
+version-neutral model — so you write your mapping once. Implement only the
+neutral handler interfaces you care about (`HeaderHandler`, `ProductHandler`,
+`CatalogGroupHandler`, `ClassificationGroupHandler` and/or `CompletionHandler`):
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/olivere/bmecat"
+)
+
+// handler works unchanged for BMEcat 1.2 and 2005 input.
+type handler struct{}
+
+func (handler) HandleHeader(h *bmecat.Header) error {
+	fmt.Printf("Catalog %q (BMEcat %s) with %d product(s)\n",
+		h.Catalog.Name, h.Version, h.NumberOfProducts)
+	return nil
+}
+
+func (handler) HandleProduct(p *bmecat.Product) error {
+	fmt.Printf("Product %s: %s (GTIN %s)\n", p.ID, p.DescriptionShort, p.GTIN)
+	return nil
+}
+
+func main() {
+	f, err := os.Open("catalog.xml")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	if err := bmecat.NewReader(f).Do(context.Background(), handler{}); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+The neutral model exposes the fields 1.2 and 2005 share; in particular
+`Product.GTIN` unifies the 1.2 `EAN` and 2005 `INTERNATIONAL_PID` elements.
+Runnable examples are in the
+[package documentation](https://pkg.go.dev/github.com/olivere/bmecat#pkg-examples).
+
+## Reading a specific version
+
+To work with a single version directly — for raw fidelity, version-specific
+fields (e.g. 2005's `PRODUCT_LOGISTIC_DETAILS`), or writing — use the
+`bmecat12` or `bmecat2005` package. Both share the same shape: implement only
+the handler interfaces you care about — `HeaderHandler`, `ArticleHandler`
+(1.2) / `ProductHandler` (2005), `CatalogGroupHandler`,
+`ClassificationGroupHandler` and/or `CompletionHandler` — and pass your handler
+to `Reader.Do`:
 
 ```go
 package main
@@ -78,9 +135,12 @@ Windows-1252, which matches how most real-world catalogs are authored.
 
 ## Writing a catalog
 
-Implement the `bmecat12.CatalogWriter` interface and hand it to `Writer.Do`.
-See the [package documentation](https://pkg.go.dev/github.com/olivere/bmecat/bmecat12)
-and the writer tests for complete, runnable examples.
+Writing is version-specific. Implement the `CatalogWriter` interface of the
+target package (`bmecat12` or `bmecat2005`) and hand it to that package's
+`Writer.Do`. See the package documentation
+([bmecat12](https://pkg.go.dev/github.com/olivere/bmecat/bmecat12),
+[bmecat2005](https://pkg.go.dev/github.com/olivere/bmecat/bmecat2005)) and the
+writer tests for complete, runnable examples.
 
 ## Command-line tool
 

--- a/adapter_v12.go
+++ b/adapter_v12.go
@@ -1,0 +1,202 @@
+package bmecat
+
+import (
+	"io"
+
+	"github.com/olivere/bmecat/bmecat12"
+)
+
+// v12Adapter implements the bmecat12 handler interfaces, converts each
+// version-specific element into the neutral type, and forwards it to the
+// caller's neutral handler. It implements all bmecat12 callbacks; each one is
+// a no-op when the caller did not provide the matching neutral handler.
+type v12Adapter struct {
+	header       HeaderHandler
+	product      ProductHandler
+	catalogGroup CatalogGroupHandler
+	classifGroup ClassificationGroupHandler
+	complete     CompletionHandler
+
+	// headerErr retains a non-EOF error returned by the neutral HeaderHandler.
+	// The bmecat12 reader currently swallows such errors (see issue #16), so
+	// the facade surfaces it after Do returns to honor the HeaderHandler
+	// contract.
+	headerErr error
+}
+
+func newV12Adapter(handler any) *v12Adapter {
+	a := &v12Adapter{}
+	if h, ok := handler.(HeaderHandler); ok {
+		a.header = h
+	}
+	if h, ok := handler.(ProductHandler); ok {
+		a.product = h
+	}
+	if h, ok := handler.(CatalogGroupHandler); ok {
+		a.catalogGroup = h
+	}
+	if h, ok := handler.(ClassificationGroupHandler); ok {
+		a.classifGroup = h
+	}
+	if h, ok := handler.(CompletionHandler); ok {
+		a.complete = h
+	}
+	return a
+}
+
+func (a *v12Adapter) HandleHeader(h *bmecat12.Header) error {
+	if a.header == nil {
+		return nil
+	}
+	err := a.header.HandleHeader(convertV12Header(h))
+	if err != nil && err != io.EOF {
+		a.headerErr = err
+	}
+	return err
+}
+
+func (a *v12Adapter) HandleArticle(art *bmecat12.Article) error {
+	if a.product == nil {
+		return nil
+	}
+	return a.product.HandleProduct(convertV12Product(art))
+}
+
+func (a *v12Adapter) HandleCatalogGroup(cg *bmecat12.CatalogGroup) error {
+	if a.catalogGroup == nil {
+		return nil
+	}
+	return a.catalogGroup.HandleCatalogGroup(&CatalogGroup{
+		Type:        cg.Type,
+		ID:          cg.ID,
+		Name:        cg.Name,
+		Description: cg.Description,
+		ParentID:    cg.ParentID,
+		Order:       cg.Order,
+	})
+}
+
+func (a *v12Adapter) HandleClassificationGroup(cg *bmecat12.ClassificationGroup) error {
+	if a.classifGroup == nil {
+		return nil
+	}
+	return a.classifGroup.HandleClassificationGroup(&ClassificationGroup{
+		Type:        cg.Type,
+		ID:          cg.ID,
+		Name:        cg.Name,
+		Description: cg.Description,
+		ParentID:    cg.ParentID,
+	})
+}
+
+func (a *v12Adapter) HandleComplete() {
+	if a.complete != nil {
+		a.complete.HandleComplete()
+	}
+}
+
+func convertV12Header(h *bmecat12.Header) *Header {
+	if h == nil {
+		return nil
+	}
+	out := &Header{
+		Version:                      Version12,
+		GeneratorInfo:                h.GeneratorInfo,
+		NumberOfProducts:             h.NumberOfArticles,
+		NumberOfCatalogGroups:        h.NumberOfCatalogGroups,
+		NumberOfClassificationGroups: h.NumberOfClassificationGroups,
+	}
+	if c := h.Catalog; c != nil {
+		out.Catalog = &Catalog{
+			Language:    c.Language,
+			ID:          c.ID,
+			Version:     c.Version,
+			Name:        c.Name,
+			Currency:    c.Currency,
+			Territories: c.Territories,
+		}
+	}
+	if b := h.Buyer; b != nil {
+		out.Buyer = &Buyer{Name: b.Name}
+		if b.ID != nil {
+			out.Buyer.ID = b.ID.Value
+		}
+	}
+	if s := h.Supplier; s != nil {
+		out.Supplier = &Supplier{Name: s.Name}
+		if s.ID != nil {
+			out.Supplier.ID = s.ID.Value
+		}
+	}
+	return out
+}
+
+func convertV12Product(a *bmecat12.Article) *Product {
+	if a == nil {
+		return nil
+	}
+	out := &Product{
+		ID:              a.SupplierAID,
+		Mode:            a.Mode,
+		CatalogGroupIDs: a.CatalogGroupIDs,
+	}
+	if d := a.Details; d != nil {
+		out.GTIN = d.EAN
+		out.DescriptionShort = d.DescriptionShort
+		out.DescriptionLong = d.DescriptionLong
+		out.SupplierAltID = d.SupplierAltAID
+		out.ManufacturerID = d.ManufacturerAID
+		out.ManufacturerName = d.ManufacturerName
+		out.Keywords = d.Keywords
+	}
+	if od := a.OrderDetails; od != nil {
+		out.OrderUnit = od.OrderUnit
+	}
+	for _, f := range a.Features {
+		out.Features = append(out.Features, convertV12Features(f))
+	}
+	for _, pd := range a.PriceDetails {
+		for _, p := range pd.Prices {
+			out.Prices = append(out.Prices, &Price{
+				Type:       p.Type,
+				Amount:     p.Amount,
+				Currency:   p.Currency,
+				Tax:        p.Tax,
+				Factor:     p.Factor,
+				LowerBound: p.LowerBound,
+				Territory:  p.Territory,
+			})
+		}
+	}
+	if mi := a.MimeInfo; mi != nil {
+		for _, m := range mi.Mimes {
+			out.Mimes = append(out.Mimes, &Mime{
+				Type:    m.Type,
+				Source:  m.Source,
+				Descr:   m.Descr,
+				Purpose: m.Purpose,
+				Order:   m.Order,
+			})
+		}
+	}
+	return out
+}
+
+func convertV12Features(f *bmecat12.ArticleFeatures) *Features {
+	if f == nil {
+		return nil
+	}
+	out := &Features{
+		SystemName: f.FeatureSystemName,
+		GroupID:    f.FeatureGroupID,
+		GroupName:  f.FeatureGroupName,
+	}
+	for _, ft := range f.Features {
+		out.Features = append(out.Features, &Feature{
+			Name:   ft.Name,
+			Values: ft.Values,
+			Unit:   ft.Unit,
+		})
+	}
+	return out
+}

--- a/adapter_v2005.go
+++ b/adapter_v2005.go
@@ -1,0 +1,215 @@
+package bmecat
+
+import "github.com/olivere/bmecat/bmecat2005"
+
+// v2005Adapter implements the bmecat2005 handler interfaces, converts each
+// version-specific element into the neutral type, and forwards it to the
+// caller's neutral handler. It implements all bmecat2005 callbacks; each one
+// is a no-op when the caller did not provide the matching neutral handler.
+type v2005Adapter struct {
+	header       HeaderHandler
+	product      ProductHandler
+	catalogGroup CatalogGroupHandler
+	classifGroup ClassificationGroupHandler
+	complete     CompletionHandler
+}
+
+func newV2005Adapter(handler any) *v2005Adapter {
+	a := &v2005Adapter{}
+	if h, ok := handler.(HeaderHandler); ok {
+		a.header = h
+	}
+	if h, ok := handler.(ProductHandler); ok {
+		a.product = h
+	}
+	if h, ok := handler.(CatalogGroupHandler); ok {
+		a.catalogGroup = h
+	}
+	if h, ok := handler.(ClassificationGroupHandler); ok {
+		a.classifGroup = h
+	}
+	if h, ok := handler.(CompletionHandler); ok {
+		a.complete = h
+	}
+	return a
+}
+
+func (a *v2005Adapter) HandleHeader(h *bmecat2005.Header) error {
+	if a.header == nil {
+		return nil
+	}
+	return a.header.HandleHeader(convertV2005Header(h))
+}
+
+func (a *v2005Adapter) HandleProduct(p *bmecat2005.Product) error {
+	if a.product == nil {
+		return nil
+	}
+	return a.product.HandleProduct(convertV2005Product(p))
+}
+
+func (a *v2005Adapter) HandleCatalogGroup(cg *bmecat2005.CatalogGroup) error {
+	if a.catalogGroup == nil {
+		return nil
+	}
+	return a.catalogGroup.HandleCatalogGroup(&CatalogGroup{
+		Type:        cg.Type,
+		ID:          cg.ID,
+		Name:        cg.Name,
+		Description: cg.Description,
+		ParentID:    cg.ParentID,
+		Order:       cg.Order,
+	})
+}
+
+func (a *v2005Adapter) HandleClassificationGroup(cg *bmecat2005.ClassificationGroup) error {
+	if a.classifGroup == nil {
+		return nil
+	}
+	return a.classifGroup.HandleClassificationGroup(&ClassificationGroup{
+		Type:        cg.Type,
+		ID:          cg.ID,
+		Name:        cg.Name,
+		Description: cg.Description,
+		ParentID:    cg.ParentID,
+	})
+}
+
+func (a *v2005Adapter) HandleComplete() {
+	if a.complete != nil {
+		a.complete.HandleComplete()
+	}
+}
+
+func convertV2005Header(h *bmecat2005.Header) *Header {
+	if h == nil {
+		return nil
+	}
+	out := &Header{
+		Version:                      Version2005,
+		GeneratorInfo:                h.GeneratorInfo,
+		NumberOfProducts:             h.NumberOfProducts,
+		NumberOfCatalogGroups:        h.NumberOfCatalogGroups,
+		NumberOfClassificationGroups: h.NumberOfClassificationGroups,
+	}
+	if c := h.Catalog; c != nil {
+		out.Catalog = &Catalog{
+			Language:    c.Language,
+			ID:          c.ID,
+			Version:     c.Version,
+			Name:        c.Name,
+			Currency:    c.Currency,
+			Territories: c.Territories,
+		}
+	}
+	if b := h.Buyer; b != nil {
+		out.Buyer = &Buyer{Name: b.Name}
+		if b.ID != nil {
+			out.Buyer.ID = b.ID.Value
+		}
+	}
+	if s := h.Supplier; s != nil {
+		out.Supplier = &Supplier{Name: s.Name}
+		if s.ID != nil {
+			out.Supplier.ID = s.ID.Value
+		}
+	}
+	return out
+}
+
+func convertV2005Product(p *bmecat2005.Product) *Product {
+	if p == nil {
+		return nil
+	}
+	out := &Product{
+		ID:              p.SupplierPID,
+		Mode:            p.Mode,
+		CatalogGroupIDs: p.CatalogGroupIDs,
+	}
+	if d := p.Details; d != nil {
+		out.GTIN = gtinFromV2005(d)
+		out.DescriptionShort = d.DescriptionShort
+		out.DescriptionLong = d.DescriptionLong
+		out.SupplierAltID = d.SupplierAltPID
+		out.ManufacturerID = d.ManufacturerPID
+		out.ManufacturerName = d.ManufacturerName
+		out.Keywords = d.Keywords
+	}
+	if od := p.OrderDetails; od != nil {
+		out.OrderUnit = od.OrderUnit
+	}
+	for _, f := range p.Features {
+		out.Features = append(out.Features, convertV2005Features(f))
+	}
+	for _, pd := range p.PriceDetails {
+		for _, pr := range pd.Prices {
+			out.Prices = append(out.Prices, &Price{
+				Type:       pr.Type,
+				Amount:     pr.Amount,
+				Currency:   pr.Currency,
+				Tax:        taxFromV2005Price(pr),
+				Factor:     pr.Factor,
+				LowerBound: pr.LowerBound,
+				Territory:  pr.Territory,
+			})
+		}
+	}
+	if mi := p.MimeInfo; mi != nil {
+		for _, m := range mi.Mimes {
+			out.Mimes = append(out.Mimes, &Mime{
+				Type:    m.Type,
+				Source:  m.Source,
+				Descr:   m.Descr,
+				Purpose: m.Purpose,
+				Order:   m.Order,
+			})
+		}
+	}
+	return out
+}
+
+// taxFromV2005Price returns the tax rate for a 2005 price: the bare TAX
+// element, falling back to the first TAX_DETAILS/TAX rate. New 2005 documents
+// carry tax under TAX_DETAILS, so without this fallback the neutral Tax would
+// be lost for them.
+func taxFromV2005Price(pr *bmecat2005.ProductPrice) *float64 {
+	if pr.Tax != nil {
+		return pr.Tax
+	}
+	for _, td := range pr.TaxDetails {
+		if td != nil && td.Tax != nil {
+			return td.Tax
+		}
+	}
+	return nil
+}
+
+// gtinFromV2005 returns the canonical GTIN/EAN for a 2005 product: the first
+// INTERNATIONAL_PID value, falling back to the legacy EAN element.
+func gtinFromV2005(d *bmecat2005.ProductDetails) string {
+	for _, pid := range d.InternationalPIDs {
+		if pid != nil && pid.Value != "" {
+			return pid.Value
+		}
+	}
+	return d.EAN
+}
+
+func convertV2005Features(f *bmecat2005.ProductFeatures) *Features {
+	if f == nil {
+		return nil
+	}
+	out := &Features{
+		SystemName: f.FeatureSystemName,
+		GroupID:    f.FeatureGroupID,
+		GroupName:  f.FeatureGroupName,
+	}
+	for _, ft := range f.Features {
+		out.Features = append(out.Features, &Feature{
+			Name:   ft.Name,
+			Values: ft.Values,
+			Unit:   ft.Unit,
+		})
+	}
+	return out
+}

--- a/doc.go
+++ b/doc.go
@@ -1,9 +1,31 @@
 /*
-Package bmecat supports reading and writing BMEcat files.
+Package bmecat supports reading BMEcat files of either supported version
+through a single, version-neutral API.
 
 BMEcat is a standard for electronic product catalogs.
 See http://www.bmecat.org/ for details about the format.
 The specifications are available at
 http://www.bme.de/initiativen/bmecat/download/.
+
+# Version-neutral reading
+
+[Reader] auto-detects the version from the root <BMECAT version="…"> element
+and dispatches to the bmecat12 or bmecat2005 reader, normalizing both into the
+version-neutral types in this package. A caller implements the handler
+interfaces it cares about ([HeaderHandler], [ProductHandler],
+[CatalogGroupHandler], [ClassificationGroupHandler], [CompletionHandler]) once,
+and ingests 1.2 and 2005 catalogs through the same code path:
+
+	r := bmecat.NewReader(file)
+	err := r.Do(ctx, handler)
+
+The neutral model exposes the fields the two versions have in common. In
+particular [Product.GTIN] unifies the 1.2 EAN element and the 2005
+INTERNATIONAL_PID element behind a single accessor.
+
+Callers that need raw, version-specific fidelity (including 2005-only fields
+such as PRODUCT_LOGISTIC_DETAILS, or writing catalogs) can use the
+github.com/olivere/bmecat/bmecat12 and github.com/olivere/bmecat/bmecat2005
+packages directly.
 */
 package bmecat

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,76 @@
+package bmecat_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/olivere/bmecat"
+)
+
+// catalogPrinter implements the neutral handler interfaces it cares about.
+// The same handler works for BMEcat 1.2 and 2005 input.
+type catalogPrinter struct{}
+
+func (catalogPrinter) HandleHeader(h *bmecat.Header) error {
+	fmt.Printf("Catalog %q (BMEcat %s)\n", h.Catalog.Name, h.Version)
+	return nil
+}
+
+func (catalogPrinter) HandleProduct(p *bmecat.Product) error {
+	fmt.Printf("- %s: %s (GTIN %s)\n", p.ID, p.DescriptionShort, p.GTIN)
+	return nil
+}
+
+// Example reads a catalog through the version-neutral facade. bmecat.NewReader
+// auto-detects the version, so the same code ingests 1.2 and 2005 documents.
+func Example() {
+	const doc = `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="2005" xmlns="http://www.bmecat.org/bmecat/2005">
+  <HEADER>
+    <CATALOG>
+      <LANGUAGE>deu</LANGUAGE>
+      <CATALOG_ID>CAT1</CATALOG_ID>
+      <CATALOG_VERSION>1.0</CATALOG_VERSION>
+      <CATALOG_NAME>Spring Catalog</CATALOG_NAME>
+    </CATALOG>
+    <SUPPLIER><SUPPLIER_NAME>SupplyCo</SUPPLIER_NAME></SUPPLIER>
+  </HEADER>
+  <T_NEW_CATALOG>
+    <PRODUCT>
+      <SUPPLIER_PID>1000</SUPPLIER_PID>
+      <PRODUCT_DETAILS>
+        <DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT>
+        <INTERNATIONAL_PID type="gtin">1234567890123</INTERNATIONAL_PID>
+      </PRODUCT_DETAILS>
+      <PRODUCT_ORDER_DETAILS><ORDER_UNIT>PCE</ORDER_UNIT></PRODUCT_ORDER_DETAILS>
+      <PRODUCT_PRICE_DETAILS>
+        <PRODUCT_PRICE price_type="net_customer"><PRICE_AMOUNT>9.99</PRICE_AMOUNT></PRODUCT_PRICE>
+      </PRODUCT_PRICE_DETAILS>
+    </PRODUCT>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+	r := bmecat.NewReader(strings.NewReader(doc))
+	if err := r.Do(context.Background(), catalogPrinter{}); err != nil {
+		panic(err)
+	}
+	// Output:
+	// Catalog "Spring Catalog" (BMEcat 2005)
+	// - 1000: Widget (GTIN 1234567890123)
+}
+
+// ExampleReader_DetectVersion shows how to detect a document's BMEcat version
+// without consuming it.
+func ExampleReader_DetectVersion() {
+	const doc = `<BMECAT version="1.2"><HEADER></HEADER><T_NEW_CATALOG></T_NEW_CATALOG></BMECAT>`
+
+	r := bmecat.NewReader(strings.NewReader(doc))
+	v, err := r.DetectVersion()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("version %s\n", v)
+	// Output:
+	// version 1.2
+}

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,34 @@
+package bmecat
+
+// The handler interfaces mirror those of the bmecat12 and bmecat2005 packages,
+// but receive the version-neutral types. A handler passed to Reader.Do may
+// implement any combination of them; only the implemented callbacks are
+// invoked.
+
+// HeaderHandler is called when the Reader passed the BMEcat HEADER element.
+//
+// HandleHeader may return io.EOF to stop the Reader from continuing to read.
+// Any other error also stops the Reader and is returned from Reader.Do.
+type HeaderHandler interface {
+	HandleHeader(*Header) error
+}
+
+// CatalogGroupHandler is called for each CATALOG_STRUCTURE element.
+type CatalogGroupHandler interface {
+	HandleCatalogGroup(*CatalogGroup) error
+}
+
+// ClassificationGroupHandler is called for each CLASSIFICATION_GROUP element.
+type ClassificationGroupHandler interface {
+	HandleClassificationGroup(*ClassificationGroup) error
+}
+
+// ProductHandler is called for each product (ARTICLE in 1.2, PRODUCT in 2005).
+type ProductHandler interface {
+	HandleProduct(*Product) error
+}
+
+// CompletionHandler is called once when the Reader is done parsing.
+type CompletionHandler interface {
+	HandleComplete()
+}

--- a/model.go
+++ b/model.go
@@ -1,0 +1,177 @@
+package bmecat
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Version identifies the BMEcat version a document was written in.
+type Version int
+
+const (
+	// Version12 is BMEcat 1.2.
+	Version12 Version = iota
+	// Version2005 is BMEcat 2005 (also known as BMEcat 2.0).
+	Version2005
+)
+
+// String returns the version attribute as it appears in a BMEcat document.
+func (v Version) String() string {
+	switch v {
+	case Version2005:
+		return "2005"
+	default:
+		return "1.2"
+	}
+}
+
+// Header is the version-neutral view of a BMEcat HEADER. It exposes the fields
+// that 1.2 and 2005 have in common.
+type Header struct {
+	// Version is the BMEcat version the document was read from.
+	Version Version
+
+	GeneratorInfo string
+	Catalog       *Catalog
+	Buyer         *Buyer
+	Supplier      *Supplier
+
+	NumberOfProducts             int
+	NumberOfCatalogGroups        int
+	NumberOfClassificationGroups int
+}
+
+// Catalog is the version-neutral view of the CATALOG element.
+type Catalog struct {
+	Language    string
+	ID          string
+	Version     string
+	Name        string
+	Currency    string
+	Territories []string
+}
+
+// Buyer is the version-neutral view of the BUYER element.
+type Buyer struct {
+	ID   string
+	Name string
+}
+
+// Supplier is the version-neutral view of the SUPPLIER element.
+type Supplier struct {
+	ID   string
+	Name string
+}
+
+// Product is the version-neutral view of a catalog product. It maps a 1.2
+// ARTICLE and a 2005 PRODUCT onto a single shape, so a caller can ingest both
+// versions through one mapping.
+type Product struct {
+	// ID is SUPPLIER_AID (1.2) or SUPPLIER_PID (2005).
+	ID string
+	// Mode is the product's transaction mode ("new", "update" or "delete").
+	// It is typically only set in T_UPDATE_PRODUCTS catalogs.
+	Mode string
+	// GTIN is the global trade item number: EAN (1.2) or the first
+	// INTERNATIONAL_PID (2005). See GTIN handling in the package docs.
+	GTIN string
+
+	DescriptionShort string
+	DescriptionLong  string
+	SupplierAltID    string
+	ManufacturerID   string
+	ManufacturerName string
+	Keywords         []string
+
+	Features  []*Features
+	OrderUnit string
+	Prices    []*Price
+	Mimes     []*Mime
+
+	// CatalogGroupIDs lists the catalog group IDs this product is mapped to.
+	CatalogGroupIDs []string
+}
+
+// Features is the version-neutral view of ARTICLE_FEATURES (1.2) /
+// PRODUCT_FEATURES (2005).
+type Features struct {
+	SystemName string
+	GroupID    string
+	GroupName  string
+	Features   []*Feature
+}
+
+// IsEclass reports whether the feature system is an eCl@ss classification.
+func (f Features) IsEclass() bool {
+	return strings.HasPrefix(strings.ToUpper(f.SystemName), "ECLASS")
+}
+
+// IsUnspsc reports whether the feature system is a UNSPSC classification.
+func (f Features) IsUnspsc() bool {
+	return strings.HasPrefix(strings.ToUpper(f.SystemName), "UNSPSC")
+}
+
+// Version returns the classification system version, e.g. "5.1" for
+// "ECLASS-5.1", or the empty string when no version is encoded.
+func (f Features) Version() string {
+	parts := strings.SplitN(f.SystemName, "-", 2)
+	if len(parts) == 2 && utf8.RuneCountInString(parts[1]) > 0 {
+		return parts[1]
+	}
+	return ""
+}
+
+// Feature is the version-neutral view of a single FEATURE.
+type Feature struct {
+	Name   string
+	Values []string
+	Unit   string
+}
+
+// Price is the version-neutral view of an ARTICLE_PRICE (1.2) / PRODUCT_PRICE
+// (2005).
+type Price struct {
+	Type       string
+	Amount     float64
+	Currency   string
+	Tax        *float64
+	Factor     float64
+	LowerBound float64
+	Territory  []string
+}
+
+// Mime is the version-neutral view of a MIME element.
+type Mime struct {
+	Type    string
+	Source  string
+	Descr   string
+	Purpose string
+	Order   int
+}
+
+// CatalogGroup is the version-neutral view of a CATALOG_STRUCTURE element.
+type CatalogGroup struct {
+	Type        string
+	ID          string
+	Name        string
+	Description string
+	ParentID    *string
+	Order       int
+}
+
+func (cg *CatalogGroup) IsRoot() bool { return cg.Type == "root" }
+func (cg *CatalogGroup) IsNode() bool { return cg.Type == "node" }
+func (cg *CatalogGroup) IsLeaf() bool { return cg.Type == "leaf" }
+
+// ClassificationGroup is the version-neutral view of a CLASSIFICATION_GROUP
+// element.
+type ClassificationGroup struct {
+	Type        string
+	ID          string
+	Name        string
+	Description string
+	ParentID    string
+}
+
+func (cg *ClassificationGroup) IsNode() bool { return cg.Type == "node" }
+func (cg *ClassificationGroup) IsLeaf() bool { return cg.Type == "leaf" }

--- a/reader.go
+++ b/reader.go
@@ -1,0 +1,169 @@
+package bmecat
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/olivere/bmecat/bmecat12"
+	"github.com/olivere/bmecat/bmecat2005"
+	"github.com/olivere/bmecat/internal"
+)
+
+// CharsetReaderFunc typedef's the CharsetReader from the Decoder in encoding/xml.
+type CharsetReaderFunc func(charset string, input io.Reader) (io.Reader, error)
+
+// Reader reads a BMEcat file of either supported version. It auto-detects the
+// version from the root <BMECAT version="…"> element and dispatches to the
+// bmecat12 or bmecat2005 reader, normalizing both into the version-neutral
+// types in this package.
+//
+// Reader is the recommended entry point. Callers that need raw, version-
+// specific fidelity can still use the bmecat12 and bmecat2005 packages
+// directly.
+type Reader struct {
+	r             io.ReadSeeker
+	charsetReader CharsetReaderFunc
+	progress      ReaderProgress
+}
+
+// NewReader creates a new Reader over r. Options such as WithCharsetReader and
+// WithReaderProgress may be passed.
+func NewReader(r io.ReadSeeker, options ...ReaderOption) *Reader {
+	reader := &Reader{
+		r:             r,
+		charsetReader: internal.AutoCharsetReader,
+	}
+	for _, o := range options {
+		o(reader)
+	}
+	return reader
+}
+
+// ReaderOption is the signature of options to pass into NewReader.
+type ReaderOption func(*Reader)
+
+// WithCharsetReader specifies the charset reader used to decode XML data. It is
+// applied both to version detection and to the underlying version reader.
+func WithCharsetReader(f CharsetReaderFunc) ReaderOption {
+	return func(r *Reader) {
+		r.charsetReader = f
+	}
+}
+
+// ReaderProgress is the signature for reporting progress. It reports the
+// current pass of the underlying parser (1 or 2) and the byte offset.
+type ReaderProgress func(pass int, offset int64)
+
+// WithReaderProgress specifies a callback invoked periodically as the file is
+// read.
+func WithReaderProgress(f ReaderProgress) ReaderOption {
+	return func(r *Reader) {
+		r.progress = f
+	}
+}
+
+// DetectVersion reports the BMEcat version of the document without consuming
+// it for the caller: it seeks back to the start before returning.
+func (r *Reader) DetectVersion() (Version, error) {
+	if _, err := r.r.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	dec := xml.NewDecoder(r.r)
+	dec.CharsetReader = r.charsetReader
+	defer r.r.Seek(0, io.SeekStart)
+
+	for {
+		t, err := dec.Token()
+		if err == io.EOF {
+			return 0, fmt.Errorf("bmecat: no BMECAT element found")
+		}
+		if err != nil {
+			return 0, err
+		}
+		se, ok := t.(xml.StartElement)
+		if !ok || se.Name.Local != "BMECAT" {
+			continue
+		}
+		// Prefer the explicit version attribute.
+		for _, attr := range se.Attr {
+			if attr.Name.Local == "version" {
+				return versionFromString(attr.Value)
+			}
+		}
+		// Fall back to the namespace, which is fixed per version.
+		if v, ok := versionFromNamespace(se.Name.Space); ok {
+			return v, nil
+		}
+		return 0, fmt.Errorf("bmecat: BMECAT element has no recognizable version")
+	}
+}
+
+func versionFromString(value string) (Version, error) {
+	switch {
+	case strings.HasPrefix(value, "1.2"):
+		return Version12, nil
+	case strings.HasPrefix(value, "2005"):
+		return Version2005, nil
+	default:
+		return 0, fmt.Errorf("bmecat: unsupported BMECAT version %q", value)
+	}
+}
+
+func versionFromNamespace(ns string) (Version, bool) {
+	switch {
+	case strings.Contains(ns, "/bmecat/1.2"):
+		return Version12, true
+	case strings.Contains(ns, "/bmecat/2005"):
+		return Version2005, true
+	default:
+		return 0, false
+	}
+}
+
+// Do reads the BMEcat file, detecting its version and dispatching to the
+// matching version reader. The handler may implement any combination of
+// HeaderHandler, CatalogGroupHandler, ClassificationGroupHandler,
+// ProductHandler and CompletionHandler.
+func (r *Reader) Do(ctx context.Context, handler any) error {
+	version, err := r.DetectVersion()
+	if err != nil {
+		return err
+	}
+
+	switch version {
+	case Version2005:
+		return r.do2005(ctx, handler)
+	default:
+		return r.do12(ctx, handler)
+	}
+}
+
+func (r *Reader) do12(ctx context.Context, handler any) error {
+	opts := []bmecat12.ReaderOption{
+		bmecat12.WithCharsetReader(bmecat12.CharsetReaderFunc(r.charsetReader)),
+	}
+	if r.progress != nil {
+		opts = append(opts, bmecat12.WithReaderProgress(bmecat12.ReaderProgress(r.progress)))
+	}
+	adapter := newV12Adapter(handler)
+	err := bmecat12.NewReader(r.r, opts...).Do(ctx, adapter)
+	if err == nil && adapter.headerErr != nil {
+		// The bmecat12 reader swallows non-EOF HandleHeader errors (#16);
+		// surface it so the neutral HeaderHandler contract holds.
+		return adapter.headerErr
+	}
+	return err
+}
+
+func (r *Reader) do2005(ctx context.Context, handler any) error {
+	opts := []bmecat2005.ReaderOption{
+		bmecat2005.WithCharsetReader(bmecat2005.CharsetReaderFunc(r.charsetReader)),
+	}
+	if r.progress != nil {
+		opts = append(opts, bmecat2005.WithReaderProgress(bmecat2005.ReaderProgress(r.progress)))
+	}
+	return bmecat2005.NewReader(r.r, opts...).Do(ctx, newV2005Adapter(handler))
+}

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,328 @@
+package bmecat_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/olivere/bmecat"
+	"github.com/olivere/bmecat/internal"
+)
+
+// The same logical catalog, encoded in both BMEcat versions. Reading either
+// through bmecat.NewReader must produce the same neutral model.
+
+const catalog12 = `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="1.2">
+  <HEADER>
+    <GENERATOR_INFO>Test</GENERATOR_INFO>
+    <CATALOG>
+      <LANGUAGE>deu</LANGUAGE>
+      <CATALOG_ID>CAT1</CATALOG_ID>
+      <CATALOG_VERSION>1.0</CATALOG_VERSION>
+      <CATALOG_NAME>Test Catalog</CATALOG_NAME>
+      <CURRENCY>EUR</CURRENCY>
+    </CATALOG>
+    <SUPPLIER>
+      <SUPPLIER_ID type="supplier">SUP</SUPPLIER_ID>
+      <SUPPLIER_NAME>SupplyCo</SUPPLIER_NAME>
+    </SUPPLIER>
+  </HEADER>
+  <T_NEW_CATALOG>
+    <ARTICLE>
+      <SUPPLIER_AID>1000</SUPPLIER_AID>
+      <ARTICLE_DETAILS>
+        <DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT>
+        <DESCRIPTION_LONG>A useful widget.</DESCRIPTION_LONG>
+        <EAN>1234567890123</EAN>
+        <MANUFACTURER_AID>MPN-1</MANUFACTURER_AID>
+        <MANUFACTURER_NAME>Acme</MANUFACTURER_NAME>
+        <KEYWORD>tool</KEYWORD>
+      </ARTICLE_DETAILS>
+      <ARTICLE_FEATURES>
+        <REFERENCE_FEATURE_SYSTEM_NAME>ECLASS-5.1</REFERENCE_FEATURE_SYSTEM_NAME>
+        <REFERENCE_FEATURE_GROUP_ID>19010203</REFERENCE_FEATURE_GROUP_ID>
+        <FEATURE><FNAME>Voltage</FNAME><FVALUE>230</FVALUE><FUNIT>VLT</FUNIT></FEATURE>
+      </ARTICLE_FEATURES>
+      <ARTICLE_ORDER_DETAILS>
+        <ORDER_UNIT>PCE</ORDER_UNIT>
+      </ARTICLE_ORDER_DETAILS>
+      <ARTICLE_PRICE_DETAILS>
+        <ARTICLE_PRICE price_type="net_customer">
+          <PRICE_AMOUNT>9.99</PRICE_AMOUNT>
+          <PRICE_CURRENCY>EUR</PRICE_CURRENCY>
+        </ARTICLE_PRICE>
+      </ARTICLE_PRICE_DETAILS>
+    </ARTICLE>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+const catalog2005 = `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="2005" xmlns="http://www.bmecat.org/bmecat/2005">
+  <HEADER>
+    <GENERATOR_INFO>Test</GENERATOR_INFO>
+    <CATALOG>
+      <LANGUAGE>deu</LANGUAGE>
+      <CATALOG_ID>CAT1</CATALOG_ID>
+      <CATALOG_VERSION>1.0</CATALOG_VERSION>
+      <CATALOG_NAME>Test Catalog</CATALOG_NAME>
+      <CURRENCY>EUR</CURRENCY>
+    </CATALOG>
+    <SUPPLIER>
+      <SUPPLIER_ID type="supplier">SUP</SUPPLIER_ID>
+      <SUPPLIER_NAME>SupplyCo</SUPPLIER_NAME>
+    </SUPPLIER>
+  </HEADER>
+  <T_NEW_CATALOG>
+    <PRODUCT>
+      <SUPPLIER_PID>1000</SUPPLIER_PID>
+      <PRODUCT_DETAILS>
+        <DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT>
+        <DESCRIPTION_LONG>A useful widget.</DESCRIPTION_LONG>
+        <INTERNATIONAL_PID type="gtin">1234567890123</INTERNATIONAL_PID>
+        <MANUFACTURER_PID>MPN-1</MANUFACTURER_PID>
+        <MANUFACTURER_NAME>Acme</MANUFACTURER_NAME>
+        <KEYWORD>tool</KEYWORD>
+      </PRODUCT_DETAILS>
+      <PRODUCT_FEATURES>
+        <REFERENCE_FEATURE_SYSTEM_NAME>ECLASS-5.1</REFERENCE_FEATURE_SYSTEM_NAME>
+        <REFERENCE_FEATURE_GROUP_ID>19010203</REFERENCE_FEATURE_GROUP_ID>
+        <FEATURE><FNAME>Voltage</FNAME><FVALUE>230</FVALUE><FUNIT>VLT</FUNIT></FEATURE>
+      </PRODUCT_FEATURES>
+      <PRODUCT_ORDER_DETAILS>
+        <ORDER_UNIT>PCE</ORDER_UNIT>
+      </PRODUCT_ORDER_DETAILS>
+      <PRODUCT_PRICE_DETAILS>
+        <PRODUCT_PRICE price_type="net_customer">
+          <PRICE_AMOUNT>9.99</PRICE_AMOUNT>
+          <PRICE_CURRENCY>EUR</PRICE_CURRENCY>
+        </PRODUCT_PRICE>
+      </PRODUCT_PRICE_DETAILS>
+    </PRODUCT>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+type collector struct {
+	header   *bmecat.Header
+	products []*bmecat.Product
+}
+
+func (c *collector) HandleHeader(h *bmecat.Header) error {
+	c.header = h
+	return nil
+}
+
+func (c *collector) HandleProduct(p *bmecat.Product) error {
+	c.products = append(c.products, p)
+	return nil
+}
+
+func read(t *testing.T, doc string) *collector {
+	t.Helper()
+	c := &collector{}
+	r := bmecat.NewReader(bytes.NewReader([]byte(doc)))
+	if err := r.Do(context.Background(), c); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return c
+}
+
+func TestDetectVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		want bmecat.Version
+	}{
+		{"1.2 attribute", catalog12, bmecat.Version12},
+		{"2005 attribute", catalog2005, bmecat.Version2005},
+		{
+			"2005 via namespace only",
+			`<?xml version="1.0"?><BMECAT xmlns="http://www.bmecat.org/bmecat/2005"><HEADER></HEADER></BMECAT>`,
+			bmecat.Version2005,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := bmecat.NewReader(bytes.NewReader([]byte(tt.doc)))
+			have, err := r.DetectVersion()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if have != tt.want {
+				t.Errorf("want version %v, have %v", tt.want, have)
+			}
+		})
+	}
+}
+
+func TestDetectVersionErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+	}{
+		{"no BMECAT element", `<?xml version="1.0"?><ROOT></ROOT>`},
+		{"unsupported version", `<BMECAT version="3.0"></BMECAT>`},
+		{"no version, unknown namespace", `<BMECAT xmlns="http://example.com/x"></BMECAT>`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := bmecat.NewReader(bytes.NewReader([]byte(tt.doc)))
+			if _, err := r.DetectVersion(); err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+		})
+	}
+}
+
+func TestReadEquivalence(t *testing.T) {
+	c12 := read(t, catalog12)
+	c2005 := read(t, catalog2005)
+
+	// Versions differ, but every other neutral field should match.
+	if want, have := bmecat.Version12, c12.header.Version; want != have {
+		t.Errorf("want 1.2 header version %v, have %v", want, have)
+	}
+	if want, have := bmecat.Version2005, c2005.header.Version; want != have {
+		t.Errorf("want 2005 header version %v, have %v", want, have)
+	}
+	c12.header.Version = 0
+	c2005.header.Version = 0
+	if !reflect.DeepEqual(c12.header, c2005.header) {
+		t.Errorf("neutral headers differ:\n 1.2: %+v\n2005: %+v", c12.header, c2005.header)
+	}
+
+	if !reflect.DeepEqual(c12.products, c2005.products) {
+		t.Errorf("neutral products differ:\n 1.2: %+v\n2005: %+v", c12.products[0], c2005.products[0])
+	}
+
+	// Spot-check the unified GTIN accessor and a carried-over helper.
+	p := c2005.products[0]
+	if want, have := "1234567890123", p.GTIN; want != have {
+		t.Errorf("want GTIN %q, have %q", want, have)
+	}
+	if len(p.Features) != 1 || !p.Features[0].IsEclass() {
+		t.Errorf("want one eCl@ss feature group, have %+v", p.Features)
+	}
+	if want, have := "5.1", p.Features[0].Version(); want != have {
+		t.Errorf("want feature system version %q, have %q", want, have)
+	}
+}
+
+func TestReadHeaderCounts(t *testing.T) {
+	c := read(t, catalog2005)
+	if c.header == nil {
+		t.Fatal("want header, have nil")
+	}
+	if want, have := 1, c.header.NumberOfProducts; want != have {
+		t.Errorf("want NumberOfProducts %d, have %d", want, have)
+	}
+}
+
+var errBoom = errors.New("boom")
+
+type failingHeaderHandler struct{}
+
+func (failingHeaderHandler) HandleHeader(*bmecat.Header) error { return errBoom }
+
+// TestReadHeaderHandlerError ensures a non-EOF error from HandleHeader is
+// surfaced for both versions, including the 1.2 path where the underlying
+// reader would otherwise swallow it (#16).
+func TestReadHeaderHandlerError(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		doc  string
+	}{
+		{"1.2", catalog12},
+		{"2005", catalog2005},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := bmecat.NewReader(bytes.NewReader([]byte(tt.doc)))
+			err := r.Do(context.Background(), failingHeaderHandler{})
+			if !errors.Is(err, errBoom) {
+				t.Fatalf("want wrapped errBoom, have %v", err)
+			}
+		})
+	}
+}
+
+// TestReadTaxDetails confirms a 2005 price expressed via TAX_DETAILS surfaces
+// as the neutral Price.Tax.
+func TestReadTaxDetails(t *testing.T) {
+	const doc = `<?xml version="1.0"?>
+<BMECAT version="2005" xmlns="http://www.bmecat.org/bmecat/2005">
+  <HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER>
+  <T_NEW_CATALOG>
+    <PRODUCT>
+      <SUPPLIER_PID>1</SUPPLIER_PID>
+      <PRODUCT_DETAILS><DESCRIPTION_SHORT>X</DESCRIPTION_SHORT></PRODUCT_DETAILS>
+      <PRODUCT_ORDER_DETAILS><ORDER_UNIT>PCE</ORDER_UNIT></PRODUCT_ORDER_DETAILS>
+      <PRODUCT_PRICE_DETAILS>
+        <PRODUCT_PRICE price_type="net_customer">
+          <PRICE_AMOUNT>10</PRICE_AMOUNT>
+          <TAX_DETAILS><TAX_TYPE>vat</TAX_TYPE><TAX>0.19</TAX></TAX_DETAILS>
+        </PRODUCT_PRICE>
+      </PRODUCT_PRICE_DETAILS>
+    </PRODUCT>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+	c := read(t, doc)
+	if len(c.products) != 1 || len(c.products[0].Prices) != 1 {
+		t.Fatalf("want one product with one price, have %+v", c.products)
+	}
+	tax := c.products[0].Prices[0].Tax
+	if tax == nil {
+		t.Fatal("want Tax from TAX_DETAILS, have nil")
+	}
+	if want, have := 0.19, *tax; want != have {
+		t.Errorf("want tax %v, have %v", want, have)
+	}
+}
+
+// TestReadProductMode confirms the product mode attribute carries into the
+// neutral model for both versions.
+func TestReadProductMode(t *testing.T) {
+	docs := map[string]string{
+		"1.2":  `<BMECAT version="1.2"><HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER><T_UPDATE_PRODUCTS prev_version="1"><ARTICLE mode="delete"><SUPPLIER_AID>1</SUPPLIER_AID></ARTICLE></T_UPDATE_PRODUCTS></BMECAT>`,
+		"2005": `<BMECAT version="2005" xmlns="http://www.bmecat.org/bmecat/2005"><HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER><T_UPDATE_PRODUCTS prev_version="1"><PRODUCT mode="delete"><SUPPLIER_PID>1</SUPPLIER_PID></PRODUCT></T_UPDATE_PRODUCTS></BMECAT>`,
+	}
+	for name, doc := range docs {
+		t.Run(name, func(t *testing.T) {
+			c := read(t, doc)
+			if len(c.products) != 1 {
+				t.Fatalf("want one product, have %d", len(c.products))
+			}
+			if want, have := "delete", c.products[0].Mode; want != have {
+				t.Errorf("want mode %q, have %q", want, have)
+			}
+		})
+	}
+}
+
+// TestReadCharset confirms the charset option is forwarded to the underlying
+// version reader.
+func TestReadCharset(t *testing.T) {
+	iso := "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>" +
+		"<BMECAT version=\"1.2\"><HEADER><CATALOG>" +
+		"<LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID>" +
+		"<CATALOG_VERSION>1</CATALOG_VERSION>" +
+		"<CATALOG_NAME>M\xfcller</CATALOG_NAME></CATALOG></HEADER>" +
+		"<T_NEW_CATALOG></T_NEW_CATALOG></BMECAT>"
+
+	c := &collector{}
+	r := bmecat.NewReader(
+		bytes.NewReader([]byte(iso)),
+		bmecat.WithCharsetReader(internal.AutoCharsetReader),
+	)
+	if err := r.Do(context.Background(), c); err != nil {
+		t.Fatal(err)
+	}
+	if c.header == nil || c.header.Catalog == nil {
+		t.Fatal("want catalog header, have nil")
+	}
+	if want, have := "Müller", c.header.Catalog.Name; want != have {
+		t.Errorf("want decoded catalog name %q, have %q", want, have)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a top-level `bmecat` package that reads catalogs of **either** supported
version through one API. `bmecat.NewReader` auto-detects the version from the
root `<BMECAT version="…">` element (with an xmlns namespace fallback) and
dispatches to the `bmecat12` or `bmecat2005` reader, normalising both into a
shared, version-neutral model — so a caller writes its product mapping once and
ingests 1.2 and 2005 catalogs through the same code path.

This is **step 2 of 2** for #8 and completes the issue (step 1 was #17, the
`bmecat2005` package).

## Design

- **Neutral model** (`model.go`): the common subset of 1.2 and 2005 —
  `Header` / `Catalog` / `Buyer` / `Supplier` / `Product` / `Features` /
  `Feature` / `Price` / `Mime` / `CatalogGroup` / `ClassificationGroup`, a
  `Version` type, and the carried-over `IsEclass()` / `IsUnspsc()` /
  `Version()` helpers.
  - `Product.GTIN` unifies the 1.2 `EAN` and 2005 `INTERNATIONAL_PID` elements.
  - The 2005 `TAX_DETAILS` tax rate falls back into the neutral `Tax`.
  - `Product.Mode` carries the `new`/`update`/`delete` attribute (both versions).
- **Handler interfaces** (`handler.go`): `HeaderHandler`, `ProductHandler`,
  `CatalogGroupHandler`, `ClassificationGroupHandler`, `CompletionHandler` —
  mirroring the version packages, but receiving neutral types.
- **Per-version adapters** (`adapter_v12.go`, `adapter_v2005.go`): each
  implements its version package's handler interfaces, converts every element
  to the neutral type, and forwards to the caller's neutral handler. All
  version differences live here.
- The facade surfaces non-EOF `HandleHeader` errors on the 1.2 path, which the
  underlying `bmecat12` reader currently swallows (#16).

## Scope

Read-only, per the issue's "version-neutral read path". Writing and raw,
version-specific fidelity (e.g. 2005's `PRODUCT_LOGISTIC_DETAILS`) remain in the
`bmecat12` and `bmecat2005` packages, which stay public.

## Tests & docs

- Version detection (+ error cases), a cross-version **equivalence test** (the
  same catalog as 1.2 and 2005 produces the same neutral model), GTIN and
  feature-helper spot checks, header counts, header-error propagation (both
  versions), `TAX_DETAILS`, product mode, and charset forwarding.
- Two runnable, output-verified `Example` functions (render on pkg.go.dev).
- README gains a "Reading any version (recommended)" section.
- `go build`, `go test -race -tags integration`, `gofumpt -l`, `go vet`, and
  `govulncheck` all pass locally.

Closes #8.