### PR TITLE
Propagate non-EOF HandleHeader errors in bmecat12 reader

### DIFF
--- a/bmecat12/coverage_test.go
+++ b/bmecat12/coverage_test.go
@@ -49,6 +49,24 @@ func TestReadArticleHandlerError(t *testing.T) {
 	}
 }
 
+type failingHeaderHandler struct{}
+
+func (failingHeaderHandler) HandleHeader(*bmecat12.Header) error { return errBoom }
+
+func TestReadHeaderHandlerError(t *testing.T) {
+	f, err := os.Open(filepath.Join("testdata", "new_catalog.golden.xml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	r := bmecat12.NewReader(f)
+	err = r.Do(context.Background(), failingHeaderHandler{})
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("expected wrapped errBoom, got %v", err)
+	}
+}
+
 // --- Reader group dispatch and completion -----------------------------------
 
 type recordingHandler struct {

--- a/bmecat12/reader.go
+++ b/bmecat12/reader.go
@@ -230,9 +230,12 @@ func (r *Reader) Do(ctx context.Context, handler any) error {
 				h.NumberOfArticleToCatalogGroupMaps = len(r.artToCatalogGroup)
 				r.artToCatalogGroupMu.Unlock()
 				if f, ok := handler.(HeaderHandler); ok {
-					if err := f.HandleHeader(&h); err == io.EOF {
-						stop = true
-						break
+					if err := f.HandleHeader(&h); err != nil {
+						if err == io.EOF {
+							stop = true
+							break
+						}
+						return fmt.Errorf("bmecat/reader: handler for HEADER returned an error around byte offset %d: %w", dec.InputOffset(), err)
 					}
 				}
 			case "CATALOG_STRUCTURE":


### PR DESCRIPTION
## Summary

The second-pass `HEADER` dispatch in `bmecat12/reader.go` only acted on `io.EOF` returned by `HandleHeader` and silently discarded any other error. This contradicted the `HeaderHandler` doc comment and diverged from the sibling `ArticleHandler` path, which wraps and returns its handler error.

Now a non-EOF error from `HandleHeader` stops the reader and is returned (wrapped) from `Reader.Do`, mirroring the behaviour already shipped in `bmecat2005`.

## Changes

- `bmecat12/reader.go`: return the wrapped handler error on non-EOF.
- `bmecat12/coverage_test.go`: port `failingHeaderHandler` + `TestReadHeaderHandlerError` from `bmecat2005` as a regression test.

## Testing

- `go build ./...`
- `go test ./...`
- `go vet ./...`

Closes #16