### PR TITLE
Use cached HeaderHandler in bmecat12 reader dispatch

### DIFF
--- a/bmecat12/reader.go
+++ b/bmecat12/reader.go
@@ -219,18 +219,18 @@ func (r *Reader) Do(ctx context.Context, handler any) error {
 		case xml.StartElement:
 			switch se.Name.Local {
 			case "HEADER":
-				var h Header
-				if err := dec.DecodeElement(&h, &se); err != nil {
+				var hdr Header
+				if err := dec.DecodeElement(&hdr, &se); err != nil {
 					return fmt.Errorf("bmecat/reader: unable to decode HEADER around byte offset %d: %w", dec.InputOffset(), err)
 				}
-				h.NumberOfArticles = numArticles
-				h.NumberOfCatalogGroups = numCatalogGroups
-				h.NumberOfClassificationGroups = numClassifGroups
+				hdr.NumberOfArticles = numArticles
+				hdr.NumberOfCatalogGroups = numCatalogGroups
+				hdr.NumberOfClassificationGroups = numClassifGroups
 				r.artToCatalogGroupMu.Lock()
-				h.NumberOfArticleToCatalogGroupMaps = len(r.artToCatalogGroup)
+				hdr.NumberOfArticleToCatalogGroupMaps = len(r.artToCatalogGroup)
 				r.artToCatalogGroupMu.Unlock()
-				if f, ok := handler.(HeaderHandler); ok {
-					if err := f.HandleHeader(&h); err != nil {
+				if h.Header != nil {
+					if err := h.Header.HandleHeader(&hdr); err != nil {
 						if err == io.EOF {
 							stop = true
 							break


### PR DESCRIPTION
## Summary

Cosmetic cleanup of the HEADER dispatch in `bmecat12/reader.go` (follow-up from #20).

- Rename the local decoded-header variable in the `case "HEADER":` block from `h` to `hdr` so it no longer shadows the outer handler struct.
- The dispatch now uses the cached `h.Header != nil` / `h.Header.HandleHeader(&hdr)` pattern, matching the other four handler branches and the `bmecat2005` reader.

This removes the dead-field `unusedwrite` finding on `h.Header` and makes all five handler dispatches uniform.

No behaviour change.

## Testing

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `gofumpt -l .` clean

Closes #21