### PR TITLE
Make cmd/bmecat 'info' version-neutral via bmecat.NewReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ writer tests for complete, runnable examples.
 ## Command-line tool
 
 The `cmd/bmecat` package contains a small CLI that demonstrates the library,
-e.g. printing the header of a catalog:
+e.g. printing the header of a catalog. It reads both BMEcat 1.2 and 2005 files,
+auto-detecting the version:
 
 ```sh
 go run ./cmd/bmecat info path/to/catalog.xml

--- a/cmd/bmecat/info.go
+++ b/cmd/bmecat/info.go
@@ -8,12 +8,13 @@ import (
 	"io"
 	"os"
 
-	"github.com/olivere/bmecat/bmecat12"
+	"github.com/olivere/bmecat"
 )
 
 // infoCommand parses the BMEcat header and prints the information found there.
+// It reads both BMEcat 1.2 and 2005 files via the version-neutral facade.
 type infoCommand struct {
-	header   *bmecat12.Header
+	header   *bmecat.Header
 	progress bool
 }
 
@@ -46,14 +47,14 @@ func (cmd *infoCommand) Run(args []string) error {
 	}
 	defer f.Close()
 
-	var o []bmecat12.ReaderOption
+	var o []bmecat.ReaderOption
 	if cmd.progress {
 		f := func(pass int, offset int64) {
 			fmt.Printf("Pass %d, Offset %6d kB\r", pass, offset/1024)
 		}
-		o = append(o, bmecat12.WithReaderProgress(f))
+		o = append(o, bmecat.WithReaderProgress(f))
 	}
-	err = bmecat12.NewReader(f, o...).Do(ctx, cmd)
+	err = bmecat.NewReader(f, o...).Do(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -65,14 +66,15 @@ func (cmd *infoCommand) Run(args []string) error {
 		return errors.New("did not receive HEADER")
 	}
 
-	fmt.Printf("%-24s: %7d\n", "Products", cmd.header.NumberOfArticles)
+	fmt.Printf("%-24s: %7s\n", "Version", cmd.header.Version)
+	fmt.Printf("%-24s: %7d\n", "Products", cmd.header.NumberOfProducts)
 	fmt.Printf("%-24s: %7d\n", "Catalog Groups", cmd.header.NumberOfCatalogGroups)
 	fmt.Printf("%-24s: %7d\n", "Classification Groups", cmd.header.NumberOfClassificationGroups)
 
 	return nil
 }
 
-func (cmd *infoCommand) HandleHeader(header *bmecat12.Header) error {
+func (cmd *infoCommand) HandleHeader(header *bmecat.Header) error {
 	cmd.header = header
 	return io.EOF
 }


### PR DESCRIPTION
## Summary

Switch `cmd/bmecat`'s `info` command to the version-neutral `bmecat.NewReader`
facade so it reads both BMEcat 1.2 and 2005 files through one path.

- Reports `NumberOfProducts`, `NumberOfCatalogGroups` and
  `NumberOfClassificationGroups` from `bmecat.Header`.
- Also prints the detected `Version` as a diagnostic line, useful now that the
  command accepts both versions.
- The `-P` progress flag carries over unchanged via `bmecat.WithReaderProgress`.
- README note that the CLI auto-detects and reads both versions.

Pure CLI change; the library packages are unaffected.

## Testing

- `go build ./...`, `go vet ./cmd/bmecat/`, `go test ./...` — all green.
- Ran `info` (with and without `-P`) against the 1.2 and 2005 golden testdata
  files; both report correct counts and the detected version.

Closes #19