### PR TITLE
Add unit tests for model helpers and adapter group dispatch

### DIFF
--- a/adapter_test.go
+++ b/adapter_test.go
@@ -1,0 +1,221 @@
+package bmecat_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/olivere/bmecat"
+)
+
+// catalogWithGroups is the same logical document in both versions, each
+// carrying one CATALOG_STRUCTURE and a CLASSIFICATION_SYSTEM with two groups.
+const catalog12Groups = `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="1.2">
+  <HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER>
+  <T_NEW_CATALOG>
+    <CATALOG_STRUCTURE type="node">
+      <GROUP_ID>10</GROUP_ID>
+      <GROUP_NAME>Hardware</GROUP_NAME>
+    </CATALOG_STRUCTURE>
+    <CLASSIFICATION_SYSTEM>
+      <CLASSIFICATION_SYSTEM_NAME>udf_Supplier-1.0</CLASSIFICATION_SYSTEM_NAME>
+      <CLASSIFICATION_GROUPS>
+        <CLASSIFICATION_GROUP type="node">
+          <CLASSIFICATION_GROUP_ID>1</CLASSIFICATION_GROUP_ID>
+          <CLASSIFICATION_GROUP_NAME>Root</CLASSIFICATION_GROUP_NAME>
+        </CLASSIFICATION_GROUP>
+        <CLASSIFICATION_GROUP type="leaf">
+          <CLASSIFICATION_GROUP_ID>2</CLASSIFICATION_GROUP_ID>
+          <CLASSIFICATION_GROUP_NAME>Leaf</CLASSIFICATION_GROUP_NAME>
+          <CLASSIFICATION_GROUP_PARENT_ID>1</CLASSIFICATION_GROUP_PARENT_ID>
+        </CLASSIFICATION_GROUP>
+      </CLASSIFICATION_GROUPS>
+    </CLASSIFICATION_SYSTEM>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+const catalog2005Groups = `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="2005" xmlns="http://www.bmecat.org/bmecat/2005">
+  <HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER>
+  <T_NEW_CATALOG>
+    <CATALOG_STRUCTURE type="node">
+      <GROUP_ID>10</GROUP_ID>
+      <GROUP_NAME>Hardware</GROUP_NAME>
+    </CATALOG_STRUCTURE>
+    <CLASSIFICATION_SYSTEM>
+      <CLASSIFICATION_SYSTEM_NAME>udf_Supplier-1.0</CLASSIFICATION_SYSTEM_NAME>
+      <CLASSIFICATION_GROUPS>
+        <CLASSIFICATION_GROUP type="node">
+          <CLASSIFICATION_GROUP_ID>1</CLASSIFICATION_GROUP_ID>
+          <CLASSIFICATION_GROUP_NAME>Root</CLASSIFICATION_GROUP_NAME>
+        </CLASSIFICATION_GROUP>
+        <CLASSIFICATION_GROUP type="leaf">
+          <CLASSIFICATION_GROUP_ID>2</CLASSIFICATION_GROUP_ID>
+          <CLASSIFICATION_GROUP_NAME>Leaf</CLASSIFICATION_GROUP_NAME>
+          <CLASSIFICATION_GROUP_PARENT_ID>1</CLASSIFICATION_GROUP_PARENT_ID>
+        </CLASSIFICATION_GROUP>
+      </CLASSIFICATION_GROUPS>
+    </CLASSIFICATION_SYSTEM>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+// groupCollector implements the catalog and classification group handlers, as
+// well as completion, so a single value exercises the adapter dispatch.
+type groupCollector struct {
+	catalogGroups []*bmecat.CatalogGroup
+	classifGroups []*bmecat.ClassificationGroup
+	completed     int
+}
+
+func (g *groupCollector) HandleCatalogGroup(cg *bmecat.CatalogGroup) error {
+	g.catalogGroups = append(g.catalogGroups, cg)
+	return nil
+}
+
+func (g *groupCollector) HandleClassificationGroup(cg *bmecat.ClassificationGroup) error {
+	g.classifGroups = append(g.classifGroups, cg)
+	return nil
+}
+
+func (g *groupCollector) HandleComplete() { g.completed++ }
+
+func TestReadGroupsDispatch(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		doc  string
+	}{
+		{"1.2", catalog12Groups},
+		{"2005", catalog2005Groups},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &groupCollector{}
+			r := bmecat.NewReader(bytes.NewReader([]byte(tt.doc)))
+			if err := r.Do(context.Background(), g); err != nil {
+				t.Fatal(err)
+			}
+
+			if want, have := 1, len(g.catalogGroups); want != have {
+				t.Fatalf("want %d catalog group(s), have %d", want, have)
+			}
+			cg := g.catalogGroups[0]
+			if want, have := "10", cg.ID; want != have {
+				t.Errorf("want catalog group ID %q, have %q", want, have)
+			}
+			if want, have := "Hardware", cg.Name; want != have {
+				t.Errorf("want catalog group name %q, have %q", want, have)
+			}
+			if !cg.IsNode() {
+				t.Errorf("want catalog group IsNode() == true for type %q", cg.Type)
+			}
+
+			if want, have := 2, len(g.classifGroups); want != have {
+				t.Fatalf("want %d classification group(s), have %d", want, have)
+			}
+			if want, have := "1", g.classifGroups[0].ID; want != have {
+				t.Errorf("want classification group ID %q, have %q", want, have)
+			}
+			if !g.classifGroups[0].IsNode() {
+				t.Errorf("want first classification group IsNode() == true")
+			}
+			if !g.classifGroups[1].IsLeaf() {
+				t.Errorf("want second classification group IsLeaf() == true")
+			}
+			if want, have := "1", g.classifGroups[1].ParentID; want != have {
+				t.Errorf("want classification group parent ID %q, have %q", want, have)
+			}
+
+			if want, have := 1, g.completed; want != have {
+				t.Errorf("want HandleComplete called %d time(s), have %d", want, have)
+			}
+		})
+	}
+}
+
+func TestNeutralCatalogGroupPredicates(t *testing.T) {
+	tests := []struct {
+		typ    string
+		isRoot bool
+		isNode bool
+		isLeaf bool
+	}{
+		{"root", true, false, false},
+		{"node", false, true, false},
+		{"leaf", false, false, true},
+		{"", false, false, false},
+	}
+	for _, tt := range tests {
+		cg := &bmecat.CatalogGroup{Type: tt.typ}
+		if got := cg.IsRoot(); got != tt.isRoot {
+			t.Errorf("IsRoot(%q) = %v, want %v", tt.typ, got, tt.isRoot)
+		}
+		if got := cg.IsNode(); got != tt.isNode {
+			t.Errorf("IsNode(%q) = %v, want %v", tt.typ, got, tt.isNode)
+		}
+		if got := cg.IsLeaf(); got != tt.isLeaf {
+			t.Errorf("IsLeaf(%q) = %v, want %v", tt.typ, got, tt.isLeaf)
+		}
+	}
+}
+
+func TestNeutralClassificationGroupPredicates(t *testing.T) {
+	if !(&bmecat.ClassificationGroup{Type: "node"}).IsNode() {
+		t.Error("IsNode() = false for node, want true")
+	}
+	if (&bmecat.ClassificationGroup{Type: "leaf"}).IsNode() {
+		t.Error("IsNode() = true for leaf, want false")
+	}
+	if !(&bmecat.ClassificationGroup{Type: "leaf"}).IsLeaf() {
+		t.Error("IsLeaf() = false for leaf, want true")
+	}
+	if (&bmecat.ClassificationGroup{Type: "node"}).IsLeaf() {
+		t.Error("IsLeaf() = true for node, want false")
+	}
+}
+
+func TestNeutralFeaturesIsUnspsc(t *testing.T) {
+	if !(bmecat.Features{SystemName: "UNSPSC-13.2"}).IsUnspsc() {
+		t.Error("IsUnspsc() = false for UNSPSC system, want true")
+	}
+	if (bmecat.Features{SystemName: "ECLASS-5.1"}).IsUnspsc() {
+		t.Error("IsUnspsc() = true for eCl@ss system, want false")
+	}
+}
+
+func TestVersionString(t *testing.T) {
+	if got, want := bmecat.Version12.String(), "1.2"; got != want {
+		t.Errorf("Version12.String() = %q, want %q", got, want)
+	}
+	if got, want := bmecat.Version2005.String(), "2005"; got != want {
+		t.Errorf("Version2005.String() = %q, want %q", got, want)
+	}
+}
+
+func TestReadWithProgress(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		doc  string
+	}{
+		{"1.2", catalog12},
+		{"2005", catalog2005},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var maxPass int
+			c := &collector{}
+			r := bmecat.NewReader(
+				bytes.NewReader([]byte(tt.doc)),
+				bmecat.WithReaderProgress(func(pass int, _ int64) {
+					if pass > maxPass {
+						maxPass = pass
+					}
+				}),
+			)
+			if err := r.Do(context.Background(), c); err != nil {
+				t.Fatal(err)
+			}
+			if maxPass < 1 {
+				t.Errorf("want progress callback invoked at least once, max pass %d", maxPass)
+			}
+		})
+	}
+}

--- a/bmecat12/model_test.go
+++ b/bmecat12/model_test.go
@@ -1,0 +1,261 @@
+package bmecat12
+
+import (
+	"testing"
+	"time"
+)
+
+func TestArticleFeaturesClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		system   string
+		isEclass bool
+		isUnspsc bool
+		version  string
+	}{
+		{"eclass lower", "eclass-5.1", true, false, "5.1"},
+		{"eclass upper", "ECLASS-7.0", true, false, "7.0"},
+		{"unspsc", "unspsc-13.2", false, true, "13.2"},
+		{"unspsc no version", "UNSPSC", false, true, ""},
+		{"unknown", "custom", false, false, ""},
+		{"empty", "", false, false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			af := ArticleFeatures{FeatureSystemName: tt.system}
+			if got := af.IsEclass(); got != tt.isEclass {
+				t.Errorf("IsEclass() = %v, want %v", got, tt.isEclass)
+			}
+			if got := af.IsUnspsc(); got != tt.isUnspsc {
+				t.Errorf("IsUnspsc() = %v, want %v", got, tt.isUnspsc)
+			}
+			if got := af.Version(); got != tt.version {
+				t.Errorf("Version() = %q, want %q", got, tt.version)
+			}
+		})
+	}
+}
+
+func TestArticlePriceDetailsValidDates(t *testing.T) {
+	apd := &ArticlePriceDetails{
+		Dates: []*DateTime{
+			{Type: DateTimeValidStartDate, DateString: "2020-01-02"},
+			{Type: DateTimeValidEndDate, DateString: "2021-03-04"},
+		},
+	}
+	if got, want := apd.ValidStartDate(), time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("ValidStartDate() = %v, want %v", got, want)
+	}
+	if got, want := apd.ValidEndDate(), time.Date(2021, 3, 4, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("ValidEndDate() = %v, want %v", got, want)
+	}
+}
+
+func TestArticlePriceDetailsValidDatesDefaults(t *testing.T) {
+	apd := &ArticlePriceDetails{}
+	if got := apd.ValidStartDate(); !got.Equal(DefaultStartDate) {
+		t.Errorf("ValidStartDate() = %v, want default %v", got, DefaultStartDate)
+	}
+	if got := apd.ValidEndDate(); !got.Equal(DefaultEndDate) {
+		t.Errorf("ValidEndDate() = %v, want default %v", got, DefaultEndDate)
+	}
+}
+
+func TestArticlePriceDetailsInvalidDatesFallBackToDefault(t *testing.T) {
+	apd := &ArticlePriceDetails{
+		Dates: []*DateTime{
+			{Type: DateTimeValidStartDate, DateString: "not-a-date"},
+			{Type: DateTimeValidEndDate, DateString: "also-bad"},
+		},
+	}
+	if got := apd.ValidStartDate(); !got.Equal(DefaultStartDate) {
+		t.Errorf("ValidStartDate() = %v, want default %v", got, DefaultStartDate)
+	}
+	if got := apd.ValidEndDate(); !got.Equal(DefaultEndDate) {
+		t.Errorf("ValidEndDate() = %v, want default %v", got, DefaultEndDate)
+	}
+}
+
+func TestArticlePriceDetailsIsDailyPrice(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"TRUE", true},
+		{"true", true},
+		{"1", true},
+		{"t", true},
+		{"T", true},
+		{"FALSE", false},
+		{"0", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		apd := ArticlePriceDetails{DailyPriceString: tt.value}
+		if got := apd.IsDailyPrice(); got != tt.want {
+			t.Errorf("IsDailyPrice(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestCatalogGroupTypePredicates(t *testing.T) {
+	tests := []struct {
+		typ    string
+		isRoot bool
+		isNode bool
+		isLeaf bool
+	}{
+		{"root", true, false, false},
+		{"node", false, true, false},
+		{"leaf", false, false, true},
+		{"", false, false, false},
+	}
+	for _, tt := range tests {
+		cg := &CatalogGroup{Type: tt.typ}
+		if got := cg.IsRoot(); got != tt.isRoot {
+			t.Errorf("IsRoot(%q) = %v, want %v", tt.typ, got, tt.isRoot)
+		}
+		if got := cg.IsNode(); got != tt.isNode {
+			t.Errorf("IsNode(%q) = %v, want %v", tt.typ, got, tt.isNode)
+		}
+		if got := cg.IsLeaf(); got != tt.isLeaf {
+			t.Errorf("IsLeaf(%q) = %v, want %v", tt.typ, got, tt.isLeaf)
+		}
+	}
+}
+
+func TestClassificationGroupTypePredicates(t *testing.T) {
+	if !(&ClassificationGroup{Type: "node"}).IsNode() {
+		t.Error("IsNode() = false for node, want true")
+	}
+	if (&ClassificationGroup{Type: "leaf"}).IsNode() {
+		t.Error("IsNode() = true for leaf, want false")
+	}
+	if !(&ClassificationGroup{Type: "leaf"}).IsLeaf() {
+		t.Error("IsLeaf() = false for leaf, want true")
+	}
+	if (&ClassificationGroup{Type: "node"}).IsLeaf() {
+		t.Error("IsLeaf() = true for node, want false")
+	}
+}
+
+func TestDateTimeTime(t *testing.T) {
+	// With explicit time.
+	dt := DateTime{DateString: "2020-06-15", TimeString: "13:45:30"}
+	got, err := dt.Time()
+	if err != nil {
+		t.Fatalf("Time() error: %v", err)
+	}
+	if want := time.Date(2020, 6, 15, 13, 45, 30, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Time() = %v, want %v", got, want)
+	}
+
+	// Missing time defaults to midnight.
+	dt = DateTime{DateString: "2020-06-15"}
+	got, err = dt.Time()
+	if err != nil {
+		t.Fatalf("Time() error: %v", err)
+	}
+	if want := time.Date(2020, 6, 15, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Time() = %v, want %v", got, want)
+	}
+
+	// Invalid date returns an error.
+	if _, err := (DateTime{DateString: "bad"}).Time(); err == nil {
+		t.Error("Time() error = nil, want non-nil for invalid date")
+	}
+}
+
+func TestAgreementStartEndDate(t *testing.T) {
+	a := &Agreement{
+		Dates: []*DateTime{
+			{Type: DateTimeAgreementStartDate, DateString: "2019-05-06"},
+			{Type: DateTimeAgreementEndDate, DateString: "2022-07-08"},
+		},
+	}
+	if got, want := a.StartDate(), time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("StartDate() = %v, want %v", got, want)
+	}
+	if got, want := a.EndDate(), time.Date(2022, 7, 8, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("EndDate() = %v, want %v", got, want)
+	}
+
+	// No dates -> defaults.
+	empty := &Agreement{}
+	if got := empty.StartDate(); !got.Equal(DefaultStartDate) {
+		t.Errorf("StartDate() = %v, want default %v", got, DefaultStartDate)
+	}
+	if got := empty.EndDate(); !got.Equal(DefaultEndDate) {
+		t.Errorf("EndDate() = %v, want default %v", got, DefaultEndDate)
+	}
+
+	// Invalid dates -> defaults.
+	bad := &Agreement{
+		Dates: []*DateTime{
+			{Type: DateTimeAgreementStartDate, DateString: "bad"},
+			{Type: DateTimeAgreementEndDate, DateString: "bad"},
+		},
+	}
+	if got := bad.StartDate(); !got.Equal(DefaultStartDate) {
+		t.Errorf("StartDate() = %v, want default %v", got, DefaultStartDate)
+	}
+	if got := bad.EndDate(); !got.Equal(DefaultEndDate) {
+		t.Errorf("EndDate() = %v, want default %v", got, DefaultEndDate)
+	}
+}
+
+func TestMimeInfoSources(t *testing.T) {
+	mi := &MimeInfo{
+		Mimes: []*Mime{
+			{Purpose: MimePurposeThumbnail, Source: "thumb.jpg"},
+			{Purpose: MimePurposeNormal, Source: "normal.jpg"},
+			{Purpose: MimePurposeDetail, Source: "detail.jpg"},
+			{Purpose: MimePurposeDataSheet, Source: "sheet.pdf"},
+			{Purpose: MimePurposeLogo, Source: "logo.png"},
+		},
+	}
+	if got, want := mi.ThumbnailSource(), "thumb.jpg"; got != want {
+		t.Errorf("ThumbnailSource() = %q, want %q", got, want)
+	}
+	if got, want := mi.NormalSource(), "normal.jpg"; got != want {
+		t.Errorf("NormalSource() = %q, want %q", got, want)
+	}
+	if got, want := mi.DetailSource(), "detail.jpg"; got != want {
+		t.Errorf("DetailSource() = %q, want %q", got, want)
+	}
+	if got, want := mi.DataSheetSource(), "sheet.pdf"; got != want {
+		t.Errorf("DataSheetSource() = %q, want %q", got, want)
+	}
+	if got, want := mi.LogoSource(), "logo.png"; got != want {
+		t.Errorf("LogoSource() = %q, want %q", got, want)
+	}
+
+	// Empty MimeInfo returns empty strings for every source.
+	empty := &MimeInfo{}
+	if got := empty.ThumbnailSource(); got != "" {
+		t.Errorf("ThumbnailSource() = %q, want empty", got)
+	}
+	if got := empty.NormalSource(); got != "" {
+		t.Errorf("NormalSource() = %q, want empty", got)
+	}
+	if got := empty.DetailSource(); got != "" {
+		t.Errorf("DetailSource() = %q, want empty", got)
+	}
+	if got := empty.DataSheetSource(); got != "" {
+		t.Errorf("DataSheetSource() = %q, want empty", got)
+	}
+	if got := empty.LogoSource(); got != "" {
+		t.Errorf("LogoSource() = %q, want empty", got)
+	}
+}
+
+func TestUDXGetNotFound(t *testing.T) {
+	var fields UserDefinedExtensionFields
+	fields.Add("A", "1")
+	if _, ok := fields.Get("MISSING"); ok {
+		t.Error("Get(MISSING) ok = true, want false")
+	}
+	if _, ok := fields.GetInnerXML("MISSING"); ok {
+		t.Error("GetInnerXML(MISSING) ok = true, want false")
+	}
+}

--- a/bmecat2005/model_test.go
+++ b/bmecat2005/model_test.go
@@ -1,0 +1,268 @@
+package bmecat2005
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProductFeaturesClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		system   string
+		isEclass bool
+		isUnspsc bool
+		version  string
+	}{
+		{"eclass lower", "eclass-5.1", true, false, "5.1"},
+		{"eclass upper", "ECLASS-7.0", true, false, "7.0"},
+		{"unspsc", "unspsc-13.2", false, true, "13.2"},
+		{"unspsc no version", "UNSPSC", false, true, ""},
+		{"unknown", "custom", false, false, ""},
+		{"empty", "", false, false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pf := ProductFeatures{FeatureSystemName: tt.system}
+			if got := pf.IsEclass(); got != tt.isEclass {
+				t.Errorf("IsEclass() = %v, want %v", got, tt.isEclass)
+			}
+			if got := pf.IsUnspsc(); got != tt.isUnspsc {
+				t.Errorf("IsUnspsc() = %v, want %v", got, tt.isUnspsc)
+			}
+			if got := pf.Version(); got != tt.version {
+				t.Errorf("Version() = %q, want %q", got, tt.version)
+			}
+		})
+	}
+}
+
+func TestProductPriceDetailsValidDates(t *testing.T) {
+	ppd := &ProductPriceDetails{
+		Dates: []*DateTime{
+			{Type: DateTimeValidStartDate, DateString: "2020-01-02"},
+			{Type: DateTimeValidEndDate, DateString: "2021-03-04"},
+		},
+	}
+	if got, want := ppd.ValidStartDate(), time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("ValidStartDate() = %v, want %v", got, want)
+	}
+	if got, want := ppd.ValidEndDate(), time.Date(2021, 3, 4, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("ValidEndDate() = %v, want %v", got, want)
+	}
+}
+
+func TestProductPriceDetailsValidDatesDefaults(t *testing.T) {
+	ppd := &ProductPriceDetails{}
+	if got := ppd.ValidStartDate(); !got.Equal(DefaultStartDate) {
+		t.Errorf("ValidStartDate() = %v, want default %v", got, DefaultStartDate)
+	}
+	if got := ppd.ValidEndDate(); !got.Equal(DefaultEndDate) {
+		t.Errorf("ValidEndDate() = %v, want default %v", got, DefaultEndDate)
+	}
+}
+
+func TestProductPriceDetailsInvalidDatesFallBackToDefault(t *testing.T) {
+	ppd := &ProductPriceDetails{
+		Dates: []*DateTime{
+			{Type: DateTimeValidStartDate, DateString: "not-a-date"},
+			{Type: DateTimeValidEndDate, DateString: "also-bad"},
+		},
+	}
+	if got := ppd.ValidStartDate(); !got.Equal(DefaultStartDate) {
+		t.Errorf("ValidStartDate() = %v, want default %v", got, DefaultStartDate)
+	}
+	if got := ppd.ValidEndDate(); !got.Equal(DefaultEndDate) {
+		t.Errorf("ValidEndDate() = %v, want default %v", got, DefaultEndDate)
+	}
+}
+
+func TestProductPriceDetailsIsDailyPrice(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"TRUE", true},
+		{"true", true},
+		{"1", true},
+		{"t", true},
+		{"T", true},
+		{"FALSE", false},
+		{"0", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		ppd := ProductPriceDetails{DailyPriceString: tt.value}
+		if got := ppd.IsDailyPrice(); got != tt.want {
+			t.Errorf("IsDailyPrice(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestCatalogGroupTypePredicates(t *testing.T) {
+	tests := []struct {
+		typ    string
+		isRoot bool
+		isNode bool
+		isLeaf bool
+	}{
+		{"root", true, false, false},
+		{"node", false, true, false},
+		{"leaf", false, false, true},
+		{"", false, false, false},
+	}
+	for _, tt := range tests {
+		cg := &CatalogGroup{Type: tt.typ}
+		if got := cg.IsRoot(); got != tt.isRoot {
+			t.Errorf("IsRoot(%q) = %v, want %v", tt.typ, got, tt.isRoot)
+		}
+		if got := cg.IsNode(); got != tt.isNode {
+			t.Errorf("IsNode(%q) = %v, want %v", tt.typ, got, tt.isNode)
+		}
+		if got := cg.IsLeaf(); got != tt.isLeaf {
+			t.Errorf("IsLeaf(%q) = %v, want %v", tt.typ, got, tt.isLeaf)
+		}
+	}
+}
+
+func TestClassificationGroupTypePredicates(t *testing.T) {
+	if !(&ClassificationGroup{Type: "node"}).IsNode() {
+		t.Error("IsNode() = false for node, want true")
+	}
+	if (&ClassificationGroup{Type: "leaf"}).IsNode() {
+		t.Error("IsNode() = true for leaf, want false")
+	}
+	if !(&ClassificationGroup{Type: "leaf"}).IsLeaf() {
+		t.Error("IsLeaf() = false for leaf, want true")
+	}
+	if (&ClassificationGroup{Type: "node"}).IsLeaf() {
+		t.Error("IsLeaf() = true for node, want false")
+	}
+}
+
+func TestDateTimeTime(t *testing.T) {
+	// With explicit time.
+	dt := DateTime{DateString: "2020-06-15", TimeString: "13:45:30"}
+	got, err := dt.Time()
+	if err != nil {
+		t.Fatalf("Time() error: %v", err)
+	}
+	if want := time.Date(2020, 6, 15, 13, 45, 30, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Time() = %v, want %v", got, want)
+	}
+
+	// Missing time defaults to midnight.
+	dt = DateTime{DateString: "2020-06-15"}
+	got, err = dt.Time()
+	if err != nil {
+		t.Fatalf("Time() error: %v", err)
+	}
+	if want := time.Date(2020, 6, 15, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Time() = %v, want %v", got, want)
+	}
+
+	// Invalid date returns an error.
+	if _, err := (DateTime{DateString: "bad"}).Time(); err == nil {
+		t.Error("Time() error = nil, want non-nil for invalid date")
+	}
+}
+
+func TestAgreementStartEndDate(t *testing.T) {
+	a := &Agreement{
+		Dates: []*DateTime{
+			{Type: DateTimeAgreementStartDate, DateString: "2019-05-06"},
+			{Type: DateTimeAgreementEndDate, DateString: "2022-07-08"},
+		},
+	}
+	if got, want := a.StartDate(), time.Date(2019, 5, 6, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("StartDate() = %v, want %v", got, want)
+	}
+	if got, want := a.EndDate(), time.Date(2022, 7, 8, 0, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("EndDate() = %v, want %v", got, want)
+	}
+
+	// No dates -> defaults.
+	empty := &Agreement{}
+	if got := empty.StartDate(); !got.Equal(DefaultStartDate) {
+		t.Errorf("StartDate() = %v, want default %v", got, DefaultStartDate)
+	}
+	if got := empty.EndDate(); !got.Equal(DefaultEndDate) {
+		t.Errorf("EndDate() = %v, want default %v", got, DefaultEndDate)
+	}
+
+	// Invalid dates -> defaults.
+	bad := &Agreement{
+		Dates: []*DateTime{
+			{Type: DateTimeAgreementStartDate, DateString: "bad"},
+			{Type: DateTimeAgreementEndDate, DateString: "bad"},
+		},
+	}
+	if got := bad.StartDate(); !got.Equal(DefaultStartDate) {
+		t.Errorf("StartDate() = %v, want default %v", got, DefaultStartDate)
+	}
+	if got := bad.EndDate(); !got.Equal(DefaultEndDate) {
+		t.Errorf("EndDate() = %v, want default %v", got, DefaultEndDate)
+	}
+}
+
+func TestMimeInfoSources(t *testing.T) {
+	mi := &MimeInfo{
+		Mimes: []*Mime{
+			{Purpose: MimePurposeThumbnail, Source: "thumb.jpg"},
+			{Purpose: MimePurposeNormal, Source: "normal.jpg"},
+			{Purpose: MimePurposeDetail, Source: "detail.jpg"},
+			{Purpose: MimePurposeDataSheet, Source: "sheet.pdf"},
+			{Purpose: MimePurposeLogo, Source: "logo.png"},
+			{Purpose: MimePurposeIcon, Source: "icon.png"},
+			{Purpose: MimePurposeSafetyDataSheet, Source: "safety.pdf"},
+		},
+	}
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Thumbnail", mi.ThumbnailSource(), "thumb.jpg"},
+		{"Normal", mi.NormalSource(), "normal.jpg"},
+		{"Detail", mi.DetailSource(), "detail.jpg"},
+		{"DataSheet", mi.DataSheetSource(), "sheet.pdf"},
+		{"Logo", mi.LogoSource(), "logo.png"},
+		{"Icon", mi.IconSource(), "icon.png"},
+		{"SafetyDataSheet", mi.SafetyDataSheetSource(), "safety.pdf"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%sSource() = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+
+	// Empty MimeInfo returns empty strings for every source.
+	empty := &MimeInfo{}
+	emptyCases := []struct {
+		name string
+		got  string
+	}{
+		{"Thumbnail", empty.ThumbnailSource()},
+		{"Normal", empty.NormalSource()},
+		{"Detail", empty.DetailSource()},
+		{"DataSheet", empty.DataSheetSource()},
+		{"Logo", empty.LogoSource()},
+		{"Icon", empty.IconSource()},
+		{"SafetyDataSheet", empty.SafetyDataSheetSource()},
+	}
+	for _, c := range emptyCases {
+		if c.got != "" {
+			t.Errorf("%sSource() = %q, want empty", c.name, c.got)
+		}
+	}
+}
+
+func TestUDXGetNotFound(t *testing.T) {
+	var fields UserDefinedExtensionFields
+	fields.Add("A", "1")
+	if _, ok := fields.Get("MISSING"); ok {
+		t.Error("Get(MISSING) ok = true, want false")
+	}
+	if _, ok := fields.GetInnerXML("MISSING"); ok {
+		t.Error("GetInnerXML(MISSING) ok = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary

Increases test coverage of the library by adding focused unit tests for the many small helper/accessor methods and adapter dispatch paths that were previously at 0%.

### Coverage changes

| Package | Before | After |
|---|---|---|
| `bmecat` (root, version-neutral facade) | 73.7% | **86.6%** |
| `bmecat12` | 63.6% | **88.7%** |
| `bmecat2005` | 62.4% | **89.3%** |

### New test files

- **`bmecat12/model_test.go`** — `ArticleFeatures.IsEclass/IsUnspsc/Version`, `ArticlePriceDetails.ValidStartDate/ValidEndDate/IsDailyPrice` (including default and invalid-date fallbacks), `CatalogGroup`/`ClassificationGroup` type predicates, `DateTime.Time` (explicit time, midnight default, parse error), `Agreement.StartDate/EndDate`, all five `MimeInfo` source accessors, and the not-found paths of `UserDefinedExtensionFields.Get/GetInnerXML`.
- **`bmecat2005/model_test.go`** — the same surface for the 2005 types, plus the 2005-only `MimeInfo.IconSource` and `SafetyDataSheetSource`.
- **`adapter_test.go`** (root) — drives `CATALOG_STRUCTURE` and `CLASSIFICATION_GROUP` dispatch through `bmecat.NewReader` for both versions (exercising the previously-untested `HandleCatalogGroup`/`HandleClassificationGroup` adapter methods), plus the neutral group predicates, `Features.IsUnspsc`, `Version.String`, and `WithReaderProgress`.

## Test plan

- [x] `go test ./...` passes
- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean

Tests only — no production code changes.