### PR TITLE
Expose order/detail fields on neutral Product

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,8 @@ jobs:
           fi
       - name: Vet
         run: go vet ./...
+      - name: Staticcheck
+        run: go tool staticcheck ./...
 
   govulncheck:
     name: Vulnerability scan

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# Tools (gofumpt, govulncheck) are managed as Go tool dependencies in go.mod
-# and invoked via `go tool`. See the `tool` directive in go.mod.
+# Tools (gofumpt, govulncheck, staticcheck) are managed as Go tool dependencies
+# in go.mod and invoked via `go tool`. See the `tool` directive in go.mod.
 # modernize lives inside gopls (an internal package), so it is run ad-hoc via
 # `go run` to avoid pulling all of gopls into the module graph.
 MODERNIZE = golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest
@@ -23,6 +23,7 @@ fmt:
 lint:
 	go tool gofumpt -l .
 	go vet ./...
+	go tool staticcheck ./...
 
 .PHONY: vulncheck
 vulncheck:

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -219,3 +219,165 @@ func TestReadWithProgress(t *testing.T) {
 		})
 	}
 }
+
+// catalog12Full and catalog2005Full carry the same product with every
+// order-detail and detail field the neutral Product exposes. The 2005 document
+// additionally sets QUANTITY_MAX, which has no 1.2 equivalent.
+const catalog12Full = `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="1.2">
+  <HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER>
+  <T_NEW_CATALOG>
+    <ARTICLE>
+      <SUPPLIER_AID>1000</SUPPLIER_AID>
+      <ARTICLE_DETAILS>
+        <DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT>
+        <BUYER_AID type="buyer">BPN-1</BUYER_AID>
+        <MANUFACTURER_TYPE_DESCR>Type-X</MANUFACTURER_TYPE_DESCR>
+        <ERP_GROUP_BUYER>EGB</ERP_GROUP_BUYER>
+        <ERP_GROUP_SUPPLIER>EGS</ERP_GROUP_SUPPLIER>
+        <DELIVERY_TIME>5</DELIVERY_TIME>
+        <SPECIAL_TREATMENT_CLASS type="WEEE">cat1</SPECIAL_TREATMENT_CLASS>
+        <KEYWORD>tool</KEYWORD>
+        <REMARKS>handle with care</REMARKS>
+        <SEGMENT>seg-a</SEGMENT>
+        <ARTICLE_STATUS type="new">live</ARTICLE_STATUS>
+      </ARTICLE_DETAILS>
+      <ARTICLE_ORDER_DETAILS>
+        <ORDER_UNIT>C62</ORDER_UNIT>
+        <CONTENT_UNIT>PCE</CONTENT_UNIT>
+        <NO_CU_PER_OU>10</NO_CU_PER_OU>
+        <PRICE_QUANTITY>100</PRICE_QUANTITY>
+        <QUANTITY_MIN>5</QUANTITY_MIN>
+        <QUANTITY_INTERVAL>5</QUANTITY_INTERVAL>
+      </ARTICLE_ORDER_DETAILS>
+      <USER_DEFINED_EXTENSIONS>
+        <UDX.SYSTEM.CUSTOM_FIELD1>custom</UDX.SYSTEM.CUSTOM_FIELD1>
+      </USER_DEFINED_EXTENSIONS>
+    </ARTICLE>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+const catalog2005Full = `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="2005" xmlns="http://www.bmecat.org/bmecat/2005">
+  <HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER>
+  <T_NEW_CATALOG>
+    <PRODUCT>
+      <SUPPLIER_PID>1000</SUPPLIER_PID>
+      <PRODUCT_DETAILS>
+        <DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT>
+        <BUYER_PID type="buyer">BPN-1</BUYER_PID>
+        <MANUFACTURER_TYPE_DESCR>Type-X</MANUFACTURER_TYPE_DESCR>
+        <ERP_GROUP_BUYER>EGB</ERP_GROUP_BUYER>
+        <ERP_GROUP_SUPPLIER>EGS</ERP_GROUP_SUPPLIER>
+        <DELIVERY_TIME>5</DELIVERY_TIME>
+        <SPECIAL_TREATMENT_CLASS type="WEEE">cat1</SPECIAL_TREATMENT_CLASS>
+        <KEYWORD>tool</KEYWORD>
+        <REMARKS>handle with care</REMARKS>
+        <SEGMENT>seg-a</SEGMENT>
+        <PRODUCT_STATUS type="new">live</PRODUCT_STATUS>
+      </PRODUCT_DETAILS>
+      <PRODUCT_ORDER_DETAILS>
+        <ORDER_UNIT>C62</ORDER_UNIT>
+        <CONTENT_UNIT>PCE</CONTENT_UNIT>
+        <NO_CU_PER_OU>10</NO_CU_PER_OU>
+        <PRICE_QUANTITY>100</PRICE_QUANTITY>
+        <QUANTITY_MIN>5</QUANTITY_MIN>
+        <QUANTITY_INTERVAL>5</QUANTITY_INTERVAL>
+        <QUANTITY_MAX>500</QUANTITY_MAX>
+      </PRODUCT_ORDER_DETAILS>
+      <USER_DEFINED_EXTENSIONS>
+        <UDX.SYSTEM.CUSTOM_FIELD1>custom</UDX.SYSTEM.CUSTOM_FIELD1>
+      </USER_DEFINED_EXTENSIONS>
+    </PRODUCT>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+func TestNeutralProductOrderAndDetailFields(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		doc             string
+		wantQuantityMax float64
+	}{
+		{"1.2", catalog12Full, 0}, // 1.2 has no QUANTITY_MAX
+		{"2005", catalog2005Full, 500},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := read(t, tt.doc)
+			if want, have := 1, len(c.products); want != have {
+				t.Fatalf("want %d product(s), have %d", want, have)
+			}
+			p := c.products[0]
+
+			// Order details.
+			if want, have := "C62", p.OrderUnit; want != have {
+				t.Errorf("OrderUnit = %q, want %q", have, want)
+			}
+			if want, have := "PCE", p.ContentUnit; want != have {
+				t.Errorf("ContentUnit = %q, want %q", have, want)
+			}
+			if want, have := 10.0, p.NoCuPerOu; want != have {
+				t.Errorf("NoCuPerOu = %v, want %v", have, want)
+			}
+			if want, have := 100.0, p.PriceQuantity; want != have {
+				t.Errorf("PriceQuantity = %v, want %v", have, want)
+			}
+			if want, have := 5.0, p.QuantityMin; want != have {
+				t.Errorf("QuantityMin = %v, want %v", have, want)
+			}
+			if want, have := 5.0, p.QuantityInterval; want != have {
+				t.Errorf("QuantityInterval = %v, want %v", have, want)
+			}
+			if want, have := tt.wantQuantityMax, p.QuantityMax; want != have {
+				t.Errorf("QuantityMax = %v, want %v", have, want)
+			}
+
+			// Article/product details.
+			if want, have := "Type-X", p.ManufacturerTypeDescr; want != have {
+				t.Errorf("ManufacturerTypeDescr = %q, want %q", have, want)
+			}
+			if want, have := "EGB", p.ERPGroupBuyer; want != have {
+				t.Errorf("ERPGroupBuyer = %q, want %q", have, want)
+			}
+			if want, have := "EGS", p.ERPGroupSupplier; want != have {
+				t.Errorf("ERPGroupSupplier = %q, want %q", have, want)
+			}
+			if p.DeliveryTime == nil {
+				t.Errorf("DeliveryTime = nil, want 5")
+			} else if want, have := 5, *p.DeliveryTime; want != have {
+				t.Errorf("DeliveryTime = %d, want %d", have, want)
+			}
+			if want, have := "handle with care", p.Remarks; want != have {
+				t.Errorf("Remarks = %q, want %q", have, want)
+			}
+			if want, have := []string{"seg-a"}, p.Segments; len(have) != 1 || have[0] != want[0] {
+				t.Errorf("Segments = %v, want %v", have, want)
+			}
+			if want, have := 1, len(p.BuyerIDs); want != have {
+				t.Fatalf("len(BuyerIDs) = %d, want %d", have, want)
+			}
+			if want, have := (bmecat.TypedValue{Type: "buyer", Value: "BPN-1"}), *p.BuyerIDs[0]; want != have {
+				t.Errorf("BuyerIDs[0] = %+v, want %+v", have, want)
+			}
+			if want, have := 1, len(p.SpecialTreatmentClasses); want != have {
+				t.Fatalf("len(SpecialTreatmentClasses) = %d, want %d", have, want)
+			}
+			if want, have := (bmecat.TypedValue{Type: "WEEE", Value: "cat1"}), *p.SpecialTreatmentClasses[0]; want != have {
+				t.Errorf("SpecialTreatmentClasses[0] = %+v, want %+v", have, want)
+			}
+			if want, have := 1, len(p.Status); want != have {
+				t.Fatalf("len(Status) = %d, want %d", have, want)
+			}
+			if want, have := (bmecat.TypedValue{Type: "new", Value: "live"}), *p.Status[0]; want != have {
+				t.Errorf("Status[0] = %+v, want %+v", have, want)
+			}
+
+			// UDX.
+			if want, have := 1, len(p.UDX); want != have {
+				t.Fatalf("len(UDX) = %d, want %d", have, want)
+			}
+			if want, have := (bmecat.UDXField{Name: "SYSTEM.CUSTOM_FIELD1", Value: "custom"}), *p.UDX[0]; want != have {
+				t.Errorf("UDX[0] = %+v, want %+v", have, want)
+			}
+		})
+	}
+}

--- a/adapter_v12.go
+++ b/adapter_v12.go
@@ -147,11 +147,39 @@ func convertV12Product(a *bmecat12.Article) *Product {
 		out.SupplierAltID = d.SupplierAltAID
 		out.ManufacturerID = d.ManufacturerAID
 		out.ManufacturerName = d.ManufacturerName
+		out.ManufacturerTypeDescr = d.ManufacturerTypeDescr
+		out.ERPGroupBuyer = d.ERPGroupBuyer
+		out.ERPGroupSupplier = d.ERPGroupSupplier
+		out.DeliveryTime = d.DeliveryTime
 		out.Keywords = d.Keywords
+		out.Remarks = d.Remarks
+		out.Segments = d.Segments
+		for _, b := range d.BuyerAIDs {
+			if b != nil {
+				out.BuyerIDs = append(out.BuyerIDs, &TypedValue{Type: b.Type, Value: b.Value})
+			}
+		}
+		for _, s := range d.SpecialTreatmentClasses {
+			if s != nil {
+				out.SpecialTreatmentClasses = append(out.SpecialTreatmentClasses, &TypedValue{Type: s.Type, Value: s.Value})
+			}
+		}
+		for _, s := range d.ArticleStatus {
+			if s != nil {
+				out.Status = append(out.Status, &TypedValue{Type: s.Type, Value: s.Value})
+			}
+		}
 	}
 	if od := a.OrderDetails; od != nil {
 		out.OrderUnit = od.OrderUnit
+		out.ContentUnit = od.ContentUnit
+		out.NoCuPerOu = od.NoCuPerOu
+		out.PriceQuantity = od.PriceQuantity
+		out.QuantityMin = od.QuantityMin
+		out.QuantityInterval = od.QuantityInterval
+		// QuantityMax has no BMEcat 1.2 equivalent; it stays zero.
 	}
+	out.UDX = convertV12UDX(a.UDX)
 	for _, f := range a.Features {
 		out.Features = append(out.Features, convertV12Features(f))
 	}
@@ -197,6 +225,19 @@ func convertV12Features(f *bmecat12.ArticleFeatures) *Features {
 			Values: ft.Values,
 			Unit:   ft.Unit,
 		})
+	}
+	return out
+}
+
+func convertV12UDX(udx *bmecat12.UserDefinedExtensions) []*UDXField {
+	if udx == nil {
+		return nil
+	}
+	var out []*UDXField
+	for _, f := range udx.Fields {
+		if f != nil {
+			out = append(out, &UDXField{Name: f.Name, Value: f.Value})
+		}
 	}
 	return out
 }

--- a/adapter_v2005.go
+++ b/adapter_v2005.go
@@ -133,11 +133,39 @@ func convertV2005Product(p *bmecat2005.Product) *Product {
 		out.SupplierAltID = d.SupplierAltPID
 		out.ManufacturerID = d.ManufacturerPID
 		out.ManufacturerName = d.ManufacturerName
+		out.ManufacturerTypeDescr = d.ManufacturerTypeDescr
+		out.ERPGroupBuyer = d.ERPGroupBuyer
+		out.ERPGroupSupplier = d.ERPGroupSupplier
+		out.DeliveryTime = d.DeliveryTime
 		out.Keywords = d.Keywords
+		out.Remarks = d.Remarks
+		out.Segments = d.Segments
+		for _, b := range d.BuyerPIDs {
+			if b != nil {
+				out.BuyerIDs = append(out.BuyerIDs, &TypedValue{Type: b.Type, Value: b.Value})
+			}
+		}
+		for _, s := range d.SpecialTreatmentClasses {
+			if s != nil {
+				out.SpecialTreatmentClasses = append(out.SpecialTreatmentClasses, &TypedValue{Type: s.Type, Value: s.Value})
+			}
+		}
+		for _, s := range d.ProductStatus {
+			if s != nil {
+				out.Status = append(out.Status, &TypedValue{Type: s.Type, Value: s.Value})
+			}
+		}
 	}
 	if od := p.OrderDetails; od != nil {
 		out.OrderUnit = od.OrderUnit
+		out.ContentUnit = od.ContentUnit
+		out.NoCuPerOu = od.NoCuPerOu
+		out.PriceQuantity = od.PriceQuantity
+		out.QuantityMin = od.QuantityMin
+		out.QuantityInterval = od.QuantityInterval
+		out.QuantityMax = od.QuantityMax
 	}
+	out.UDX = convertV2005UDX(p.UDX)
 	for _, f := range p.Features {
 		out.Features = append(out.Features, convertV2005Features(f))
 	}
@@ -210,6 +238,19 @@ func convertV2005Features(f *bmecat2005.ProductFeatures) *Features {
 			Values: ft.Values,
 			Unit:   ft.Unit,
 		})
+	}
+	return out
+}
+
+func convertV2005UDX(udx *bmecat2005.UserDefinedExtensions) []*UDXField {
+	if udx == nil {
+		return nil
+	}
+	var out []*UDXField
+	for _, f := range udx.Fields {
+		if f != nil {
+			out = append(out, &UDXField{Name: f.Name, Value: f.Value})
+		}
 	}
 	return out
 }

--- a/cmd/bmecat/main.go
+++ b/cmd/bmecat/main.go
@@ -86,7 +86,7 @@ func usage(msg string) {
 	}
 	sort.Strings(modes)
 	for _, mode := range modes {
-		cmd, _ := modeCommand[mode]
+		cmd := modeCommand[mode]
 		if des, ok := cmd.(describer); ok {
 			Errorf("  %-25s %s\n", mode, des.Describe())
 		}
@@ -143,6 +143,14 @@ func main() {
 	}
 
 	mode := args[0]
+	if mode == "help" {
+		if len(args) < 2 {
+			usage("No mode given for help.")
+		}
+		help(args[1])
+		Exit(0)
+	}
+
 	cmd, ok := modeCommand[mode]
 	if !ok {
 		usage(fmt.Sprintf("Unknown mode %q", mode))

--- a/go.mod
+++ b/go.mod
@@ -8,16 +8,20 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
+	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260617140237-9b6dc03d9327 // indirect
 	golang.org/x/tools v0.46.0 // indirect
 	golang.org/x/vuln v1.4.0 // indirect
+	honnef.co/go/tools v0.7.0 // indirect
 	mvdan.cc/gofumpt v0.10.0 // indirect
 )
 
 tool (
 	golang.org/x/vuln/cmd/govulncheck
+	honnef.co/go/tools/cmd/staticcheck
 	mvdan.cc/gofumpt
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/go-quicktest/qt v1.102.0 h1:HSQxCeh5YZH3EL3W39ixjtyaEhcWSXQHtHnMBzSs474=
 github.com/go-quicktest/qt v1.102.0/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/google/go-cmdtest v0.4.1-0.20220921163831-55ab3332a786 h1:rcv+Ippz6RAtvaGgKxc+8FQIpxHgsF+HBzPyYL2cyVU=
@@ -12,6 +14,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
@@ -32,5 +36,7 @@ golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTF
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
 golang.org/x/vuln v1.4.0 h1:FpmTZiV4PyqY3lFfuCkz1JftEXb/+8M2NEkjJM5TF4g=
 golang.org/x/vuln v1.4.0/go.mod h1:FJ7XyKs83nAdxQ7PMsia2PoynwZMJ/QajXVMBBIgFe8=
+honnef.co/go/tools v0.7.0 h1:w6WUp1VbkqPEgLz4rkBzH/CSU6HkoqNLp6GstyTx3lU=
+honnef.co/go/tools v0.7.0/go.mod h1:pm29oPxeP3P82ISxZDgIYeOaf9ta6Pi0EWvCFoLG2vc=
 mvdan.cc/gofumpt v0.10.0 h1:yGGpRS2pBN2OQIi7b21IXknJna7faPkFaVfHLrN6Euo=
 mvdan.cc/gofumpt v0.10.0/go.mod h1:sU2ElXHzOEmvoPqfutYG7uunlueR4K2T1JFml40SzP4=

--- a/model.go
+++ b/model.go
@@ -81,15 +81,69 @@ type Product struct {
 	SupplierAltID    string
 	ManufacturerID   string
 	ManufacturerName string
-	Keywords         []string
+	// ManufacturerTypeDescr is MANUFACTURER_TYPE_DESCR.
+	ManufacturerTypeDescr string
+	Keywords              []string
+	// Remarks is REMARKS.
+	Remarks string
+	// Segments is the list of SEGMENT values.
+	Segments []string
 
-	Features  []*Features
-	OrderUnit string
-	Prices    []*Price
-	Mimes     []*Mime
+	// ERPGroupBuyer and ERPGroupSupplier are ERP_GROUP_BUYER /
+	// ERP_GROUP_SUPPLIER.
+	ERPGroupBuyer    string
+	ERPGroupSupplier string
+	// DeliveryTime is DELIVERY_TIME (the lead time). It is nil when the source
+	// document omits it.
+	DeliveryTime *int
+	// BuyerIDs are the buyer-specific product identifiers: BUYER_AID (1.2) /
+	// BUYER_PID (2005).
+	BuyerIDs []*TypedValue
+	// SpecialTreatmentClasses are SPECIAL_TREATMENT_CLASS entries.
+	SpecialTreatmentClasses []*TypedValue
+	// Status are the ARTICLE_STATUS (1.2) / PRODUCT_STATUS (2005) entries.
+	Status []*TypedValue
+
+	Features []*Features
+
+	// Order detail fields, from ARTICLE_ORDER_DETAILS (1.2) /
+	// PRODUCT_ORDER_DETAILS (2005).
+	OrderUnit        string
+	ContentUnit      string
+	NoCuPerOu        float64
+	PriceQuantity    float64
+	QuantityMin      float64
+	QuantityInterval float64
+	// QuantityMax is QUANTITY_MAX. It exists only in BMEcat 2005; for 1.2 it is
+	// always zero, because 1.2 has no QUANTITY_MAX element.
+	QuantityMax float64
+
+	Prices []*Price
+	Mimes  []*Mime
+
+	// UDX carries USER_DEFINED_EXTENSIONS as neutral name/value pairs. Callers
+	// that need raw or nested UDX XML should read the bmecat12/bmecat2005
+	// packages directly.
+	UDX []*UDXField
 
 	// CatalogGroupIDs lists the catalog group IDs this product is mapped to.
 	CatalogGroupIDs []string
+}
+
+// TypedValue is the version-neutral view of an element that carries a type
+// attribute and a character-data value, such as BUYER_AID/BUYER_PID,
+// SPECIAL_TREATMENT_CLASS, and ARTICLE_STATUS/PRODUCT_STATUS.
+type TypedValue struct {
+	Type  string
+	Value string
+}
+
+// UDXField is a single user-defined extension, the version-neutral view of a
+// USER_DEFINED_EXTENSIONS child element. Name is the field name without the
+// "UDX." prefix (e.g. "SYSTEM.CUSTOM_FIELD1").
+type UDXField struct {
+	Name  string
+	Value string
 }
 
 // Features is the version-neutral view of ARTICLE_FEATURES (1.2) /


### PR DESCRIPTION
Closes #27.

## What

The version-neutral `bmecat.Product` previously carried only `OrderUnit` from order details plus a small subset of detail fields, silently dropping data the underlying `bmecat12`/`bmecat2005` structs already parse. This extends `Product` and both adapters to map the rest.

### Order details
`ContentUnit`, `NoCuPerOu`, `PriceQuantity`, `QuantityMin`, `QuantityInterval`, `QuantityMax`.

`QuantityMax` (`QUANTITY_MAX`) exists **only in BMEcat 2005** — the 1.2 adapter leaves it zero, which honestly reflects that 1.2 has no such element.

`PriceQuantity` was the motivating gap: it's the base quantity a price refers to (e.g. price "per 100"), and consumers previously couldn't read it through the facade at all.

### Detail fields
`ManufacturerTypeDescr`, `ERPGroupBuyer`, `ERPGroupSupplier`, `DeliveryTime`, `Remarks`, `Segments`, `BuyerIDs` (BUYER_AID / BUYER_PID), `SpecialTreatmentClasses`, `Status` (ARTICLE_STATUS / PRODUCT_STATUS), and `UDX`.

Two new neutral types back these:
- `TypedValue{Type, Value}` — for the type+chardata elements (buyer IDs, special treatment classes, status).
- `UDXField{Name, Value}` — neutral name/value view of USER_DEFINED_EXTENSIONS. Callers needing raw/nested UDX XML should use the concrete packages directly.

`brand` is intentionally **not** included — no such field is parsed anywhere in `bmecat12`/`bmecat2005` (BMEcat 1.2 has no BRAND element), so it would be a separate parsing change, not a facade fix. See #27.

## Incidental fixes
- Wire up the advertised `bmecat help <mode>` command — it was documented in `usage()` but `main` never dispatched to the existing `help()` func (so the func was dead code and the command was broken).
- Add **staticcheck** as a go.mod tool dependency, run by `make lint` and CI alongside `go vet`. Fixed the one pre-existing finding it surfaced (S1005 in cmd/bmecat).

## Testing
- New `TestNeutralProductOrderAndDetailFields` reads a fully-populated product in both 1.2 and 2005 and asserts every mapped field, including `QuantityMax` populated for 2005 and zero for 1.2.
- `go vet`, `staticcheck`, `gofumpt`, and `go test -race ./...` all pass.