### PR TITLE
Expose BMEcat transaction type on the read path (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ The neutral model exposes the fields 1.2 and 2005 share; in particular
 Runnable examples are in the
 [package documentation](https://pkg.go.dev/github.com/olivere/bmecat#pkg-examples).
 
+To gate on the document-level transaction — for example to accept only full
+catalogs and reject incremental updates — call `DetectTransaction` before `Do`
+(it rewinds, like `DetectVersion`); the same value is also available as
+`Header.Transaction` during a full parse:
+
+```go
+r := bmecat.NewReader(f)
+if tx, err := r.DetectTransaction(); err != nil {
+	return err
+} else if tx.IsUpdate() {
+	return fmt.Errorf("only full catalogs are supported, got %s", tx)
+}
+```
+
 ## Reading a specific version
 
 To work with a single version directly — for raw fidelity, version-specific

--- a/adapter_v12.go
+++ b/adapter_v12.go
@@ -17,6 +17,10 @@ type v12Adapter struct {
 	classifGroup ClassificationGroupHandler
 	complete     CompletionHandler
 
+	// transaction is the document-level transaction detected in phase 1; it is
+	// stamped onto the neutral Header, which the version-specific Header lacks.
+	transaction Transaction
+
 	// headerErr retains a non-EOF error returned by the neutral HeaderHandler.
 	// The bmecat12 reader currently swallows such errors (see issue #16), so
 	// the facade surfaces it after Do returns to honor the HeaderHandler
@@ -24,8 +28,8 @@ type v12Adapter struct {
 	headerErr error
 }
 
-func newV12Adapter(handler any) *v12Adapter {
-	a := &v12Adapter{}
+func newV12Adapter(handler any, transaction Transaction) *v12Adapter {
+	a := &v12Adapter{transaction: transaction}
 	if h, ok := handler.(HeaderHandler); ok {
 		a.header = h
 	}
@@ -48,7 +52,9 @@ func (a *v12Adapter) HandleHeader(h *bmecat12.Header) error {
 	if a.header == nil {
 		return nil
 	}
-	err := a.header.HandleHeader(convertV12Header(h))
+	hdr := convertV12Header(h)
+	hdr.Transaction = a.transaction
+	err := a.header.HandleHeader(hdr)
 	if err != nil && err != io.EOF {
 		a.headerErr = err
 	}

--- a/adapter_v2005.go
+++ b/adapter_v2005.go
@@ -12,10 +12,14 @@ type v2005Adapter struct {
 	catalogGroup CatalogGroupHandler
 	classifGroup ClassificationGroupHandler
 	complete     CompletionHandler
+
+	// transaction is the document-level transaction detected in phase 1; it is
+	// stamped onto the neutral Header, which the version-specific Header lacks.
+	transaction Transaction
 }
 
-func newV2005Adapter(handler any) *v2005Adapter {
-	a := &v2005Adapter{}
+func newV2005Adapter(handler any, transaction Transaction) *v2005Adapter {
+	a := &v2005Adapter{transaction: transaction}
 	if h, ok := handler.(HeaderHandler); ok {
 		a.header = h
 	}
@@ -38,7 +42,9 @@ func (a *v2005Adapter) HandleHeader(h *bmecat2005.Header) error {
 	if a.header == nil {
 		return nil
 	}
-	return a.header.HandleHeader(convertV2005Header(h))
+	hdr := convertV2005Header(h)
+	hdr.Transaction = a.transaction
+	return a.header.HandleHeader(hdr)
 }
 
 func (a *v2005Adapter) HandleProduct(p *bmecat2005.Product) error {

--- a/doc.go
+++ b/doc.go
@@ -23,6 +23,20 @@ The neutral model exposes the fields the two versions have in common. In
 particular [Product.GTIN] unifies the 1.2 EAN element and the 2005
 INTERNATIONAL_PID element behind a single accessor.
 
+A caller that needs to gate on the document-level transaction — for example to
+reject incremental updates and only accept full catalogs — can detect it cheaply
+in phase 1, mirroring [Reader.DetectVersion]:
+
+	switch tx, err := r.DetectTransaction(); {
+	case err != nil:
+		return err
+	case tx.IsUpdate():
+		return fmt.Errorf("only full catalogs are supported, got %s", tx)
+	}
+
+The same value is also surfaced on [Header.Transaction] during Do, for callers
+that read it as part of a full parse.
+
 Callers that need raw, version-specific fidelity (including 2005-only fields
 such as PRODUCT_LOGISTIC_DETAILS, or writing catalogs) can use the
 github.com/olivere/bmecat/bmecat12 and github.com/olivere/bmecat/bmecat2005

--- a/model.go
+++ b/model.go
@@ -25,11 +25,65 @@ func (v Version) String() string {
 	}
 }
 
+// Transaction identifies the document-level BMEcat transaction: a full catalog
+// (NewCatalog) or an incremental update (UpdateProducts / UpdatePrices). It is
+// the wrapping T_NEW_CATALOG / T_UPDATE_PRODUCTS / T_UPDATE_PRICES element, not
+// the per-product Product.Mode.
+type Transaction int
+
+const (
+	// NewCatalog is a full catalog: T_NEW_CATALOG.
+	NewCatalog Transaction = iota
+	// UpdateProducts is an incremental product update: T_UPDATE_PRODUCTS.
+	UpdateProducts
+	// UpdatePrices is an incremental price update: T_UPDATE_PRICES.
+	UpdatePrices
+)
+
+// String returns the transaction element name as it appears in a BMEcat
+// document, e.g. "T_NEW_CATALOG".
+func (t Transaction) String() string {
+	switch t {
+	case UpdateProducts:
+		return "T_UPDATE_PRODUCTS"
+	case UpdatePrices:
+		return "T_UPDATE_PRICES"
+	default:
+		return "T_NEW_CATALOG"
+	}
+}
+
+// IsUpdate reports whether the transaction is an incremental update
+// (T_UPDATE_PRODUCTS or T_UPDATE_PRICES) rather than a full catalog. A consumer
+// that only supports full catalogs can reject updates with this.
+func (t Transaction) IsUpdate() bool {
+	return t == UpdateProducts || t == UpdatePrices
+}
+
+// transactionFromElement maps a transaction start-element name onto a
+// Transaction. The second result is false for any other element.
+func transactionFromElement(name string) (Transaction, bool) {
+	switch name {
+	case "T_NEW_CATALOG":
+		return NewCatalog, true
+	case "T_UPDATE_PRODUCTS":
+		return UpdateProducts, true
+	case "T_UPDATE_PRICES":
+		return UpdatePrices, true
+	default:
+		return 0, false
+	}
+}
+
 // Header is the version-neutral view of a BMEcat HEADER. It exposes the fields
 // that 1.2 and 2005 have in common.
 type Header struct {
 	// Version is the BMEcat version the document was read from.
 	Version Version
+	// Transaction is the document-level transaction the products are wrapped
+	// in: NewCatalog for a full catalog, UpdateProducts / UpdatePrices for an
+	// incremental update. It is distinct from the per-product Product.Mode.
+	Transaction Transaction
 
 	GeneratorInfo string
 	Catalog       *Catalog

--- a/reader.go
+++ b/reader.go
@@ -101,6 +101,52 @@ func (r *Reader) DetectVersion() (Version, error) {
 	}
 }
 
+// DetectTransaction reports the document-level BMEcat transaction without
+// consuming the document for the caller: it seeks back to the start before
+// returning.
+//
+// It mirrors DetectVersion and is the cheap, phase-1 way to gate on the
+// transaction — for example to reject incremental updates (Transaction.IsUpdate)
+// up front, without the full parse that Do performs. The same value is also
+// surfaced on Header.Transaction during Do.
+func (r *Reader) DetectTransaction() (Transaction, error) {
+	if _, err := r.r.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	dec := xml.NewDecoder(r.r)
+	dec.CharsetReader = r.charsetReader
+	defer r.r.Seek(0, io.SeekStart)
+
+	var inBMECAT bool
+	for {
+		t, err := dec.Token()
+		if err == io.EOF {
+			return 0, fmt.Errorf("bmecat: no transaction element found")
+		}
+		if err != nil {
+			return 0, err
+		}
+		se, ok := t.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		if !inBMECAT {
+			if se.Name.Local == "BMECAT" {
+				inBMECAT = true
+			}
+			continue
+		}
+		// The transaction element is the first non-HEADER child of BMECAT.
+		if tx, ok := transactionFromElement(se.Name.Local); ok {
+			return tx, nil
+		}
+		// Skip other children (e.g. HEADER) without descending into them.
+		if err := dec.Skip(); err != nil {
+			return 0, err
+		}
+	}
+}
+
 func versionFromString(value string) (Version, error) {
 	switch {
 	case strings.HasPrefix(value, "1.2"):
@@ -132,23 +178,27 @@ func (r *Reader) Do(ctx context.Context, handler any) error {
 	if err != nil {
 		return err
 	}
+	transaction, err := r.DetectTransaction()
+	if err != nil {
+		return err
+	}
 
 	switch version {
 	case Version2005:
-		return r.do2005(ctx, handler)
+		return r.do2005(ctx, handler, transaction)
 	default:
-		return r.do12(ctx, handler)
+		return r.do12(ctx, handler, transaction)
 	}
 }
 
-func (r *Reader) do12(ctx context.Context, handler any) error {
+func (r *Reader) do12(ctx context.Context, handler any, transaction Transaction) error {
 	opts := []bmecat12.ReaderOption{
 		bmecat12.WithCharsetReader(bmecat12.CharsetReaderFunc(r.charsetReader)),
 	}
 	if r.progress != nil {
 		opts = append(opts, bmecat12.WithReaderProgress(bmecat12.ReaderProgress(r.progress)))
 	}
-	adapter := newV12Adapter(handler)
+	adapter := newV12Adapter(handler, transaction)
 	err := bmecat12.NewReader(r.r, opts...).Do(ctx, adapter)
 	if err == nil && adapter.headerErr != nil {
 		// The bmecat12 reader swallows non-EOF HandleHeader errors (#16);
@@ -158,12 +208,12 @@ func (r *Reader) do12(ctx context.Context, handler any) error {
 	return err
 }
 
-func (r *Reader) do2005(ctx context.Context, handler any) error {
+func (r *Reader) do2005(ctx context.Context, handler any, transaction Transaction) error {
 	opts := []bmecat2005.ReaderOption{
 		bmecat2005.WithCharsetReader(bmecat2005.CharsetReaderFunc(r.charsetReader)),
 	}
 	if r.progress != nil {
 		opts = append(opts, bmecat2005.WithReaderProgress(bmecat2005.ReaderProgress(r.progress)))
 	}
-	return bmecat2005.NewReader(r.r, opts...).Do(ctx, newV2005Adapter(handler))
+	return bmecat2005.NewReader(r.r, opts...).Do(ctx, newV2005Adapter(handler, transaction))
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -326,3 +326,103 @@ func TestReadCharset(t *testing.T) {
 		t.Errorf("want decoded catalog name %q, have %q", want, have)
 	}
 }
+
+// updateDoc builds a minimal catalog wrapped in the given transaction element
+// for the given version, so the transaction tests can exercise every
+// (version, transaction) combination.
+func updateDoc(version, txElem string) string {
+	switch version {
+	case "2005":
+		return `<BMECAT version="2005" xmlns="http://www.bmecat.org/bmecat/2005"><HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER><` + txElem + ` prev_version="1"><PRODUCT><SUPPLIER_PID>1</SUPPLIER_PID></PRODUCT></` + txElem + `></BMECAT>`
+	default:
+		return `<BMECAT version="1.2"><HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER><` + txElem + ` prev_version="1"><ARTICLE><SUPPLIER_AID>1</SUPPLIER_AID></ARTICLE></` + txElem + `></BMECAT>`
+	}
+}
+
+// TestDetectTransaction covers option 1 from #29: the phase-1 detector reports
+// the wrapping transaction for both versions and seeks back so a later Do still
+// reads the whole document.
+func TestDetectTransaction(t *testing.T) {
+	tests := []struct {
+		txElem string
+		want   bmecat.Transaction
+	}{
+		{"T_NEW_CATALOG", bmecat.NewCatalog},
+		{"T_UPDATE_PRODUCTS", bmecat.UpdateProducts},
+		{"T_UPDATE_PRICES", bmecat.UpdatePrices},
+	}
+	for _, version := range []string{"1.2", "2005"} {
+		for _, tt := range tests {
+			t.Run(version+"/"+tt.txElem, func(t *testing.T) {
+				r := bmecat.NewReader(bytes.NewReader([]byte(updateDoc(version, tt.txElem))))
+				have, err := r.DetectTransaction()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if have != tt.want {
+					t.Fatalf("want transaction %v, have %v", tt.want, have)
+				}
+				// DetectTransaction must rewind: a subsequent Do still sees the product.
+				c := &collector{}
+				if err := r.Do(context.Background(), c); err != nil {
+					t.Fatal(err)
+				}
+				if len(c.products) != 1 {
+					t.Errorf("want one product after detect+read, have %d", len(c.products))
+				}
+			})
+		}
+	}
+}
+
+// TestDetectTransactionErrors confirms a document without a transaction element
+// reports an error rather than a bogus zero value.
+func TestDetectTransactionErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+	}{
+		{"no BMECAT element", `<?xml version="1.0"?><ROOT></ROOT>`},
+		{"header only, no transaction", `<BMECAT version="1.2"><HEADER></HEADER></BMECAT>`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := bmecat.NewReader(bytes.NewReader([]byte(tt.doc)))
+			if _, err := r.DetectTransaction(); err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+		})
+	}
+}
+
+// TestReadHeaderTransaction covers option 2 from #29: the transaction is
+// surfaced on the neutral Header during Do, for both versions.
+func TestReadHeaderTransaction(t *testing.T) {
+	for _, version := range []string{"1.2", "2005"} {
+		t.Run(version, func(t *testing.T) {
+			c := read(t, updateDoc(version, "T_UPDATE_PRICES"))
+			if c.header == nil {
+				t.Fatal("want header, have nil")
+			}
+			if want, have := bmecat.UpdatePrices, c.header.Transaction; want != have {
+				t.Errorf("want Header.Transaction %v, have %v", want, have)
+			}
+			if !c.header.Transaction.IsUpdate() {
+				t.Error("want IsUpdate true for T_UPDATE_PRICES")
+			}
+		})
+	}
+}
+
+// TestTransactionString pins the element names a Transaction stringifies to.
+func TestTransactionString(t *testing.T) {
+	for tx, want := range map[bmecat.Transaction]string{
+		bmecat.NewCatalog:     "T_NEW_CATALOG",
+		bmecat.UpdateProducts: "T_UPDATE_PRODUCTS",
+		bmecat.UpdatePrices:   "T_UPDATE_PRICES",
+	} {
+		if have := tx.String(); have != want {
+			t.Errorf("want %q, have %q", want, have)
+		}
+	}
+}


### PR DESCRIPTION
Closes #29.

Exposes the BMEcat document-level **transaction** (`T_NEW_CATALOG` / `T_UPDATE_PRODUCTS` / `T_UPDATE_PRICES`) on the read path. Implements **both** APIs the issue proposed; they share one new neutral `Transaction` type, distinct from the per-product `Product.Mode`.

## What changed

- **`Transaction` type** (`model.go`) — `NewCatalog` / `UpdateProducts` / `UpdatePrices`, iota-aligned with the existing writer enums, with `String()` (element name) and an `IsUpdate()` helper for the "reject incremental updates" use case.
- **Option 1 — phase-1 detection (the issue's preferred):** `(*Reader).DetectTransaction() (Transaction, error)`, mirroring `DetectVersion()`. Scans the lead-in (BMECAT → skip HEADER → first transaction element) and seeks back, so a later `Do` still reads the whole document. Cheap gate, no full parse.
- **Option 2 — on the read model:** `Header.Transaction` field, populated during `Do` and threaded through both version adapters (the version-specific headers don't carry it).

A consumer that only supports full catalogs can now reject updates up front without a separate `encoding/xml` pre-scan:

```go
r := bmecat.NewReader(f)
if tx, err := r.DetectTransaction(); err != nil {
	return err
} else if tx.IsUpdate() {
	return fmt.Errorf("only full catalogs are supported, got %s", tx)
}
```

## Tests

- `TestDetectTransaction` — all six version×transaction combinations, asserts the detector rewinds so a subsequent `Do` still reads the product.
- `TestDetectTransactionErrors`, `TestReadHeaderTransaction`, `TestTransactionString`.

All checks green: `go build`, `go vet`, `gofumpt -l`, `staticcheck`, and `go test -race -tags integration ./...`.

## Note

Both `DetectTransaction` and `Header.Transaction` are public and do the same job by design, since the issue asked for both. Easy to drop one if a smaller surface is preferred.