### PR TITLE
Add version-neutral streaming catalog writer (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,55 @@ Windows-1252, which matches how most real-world catalogs are authored.
 
 ## Writing a catalog
 
-Writing is version-specific. Implement the `CatalogWriter` interface of the
-target package (`bmecat12` or `bmecat2005`) and hand it to that package's
+### Version-neutral writing
+
+`bmecat.NewWriter` is the streaming, write-path counterpart of
+`bmecat.NewReader`: implement a neutral `CatalogWriter` (a header plus a channel
+of products), pick a target version with `WithVersion`, and the writer emits a
+valid BMEcat 1.2 or 2005 document, converting the neutral model to the
+version-specific one for you. Like reading, writing is streaming — each product
+is converted and encoded as it arrives, so even a catalog of millions of
+products is never held in memory at once.
+
+```go
+// catalog implements bmecat.CatalogWriter.
+type catalog struct{ /* e.g. a database handle */ }
+
+func (catalog) Header() *bmecat.Header { return header }
+
+func (c catalog) Products(ctx context.Context) (<-chan *bmecat.Product, <-chan error) {
+	out := make(chan *bmecat.Product)
+	errc := make(chan error, 1)
+	go func() {
+		defer close(out)
+		for _, p := range c.stream() { // e.g. rows from a database cursor
+			select {
+			case out <- p:
+			case <-ctx.Done():
+				errc <- ctx.Err()
+				return
+			}
+		}
+	}()
+	return out, errc
+}
+
+// ...
+w := bmecat.NewWriter(out, bmecat.WithVersion(bmecat.Version2005))
+if err := w.Do(context.Background(), catalog{}); err != nil {
+	return err
+}
+```
+
+The neutral model carries the fields 1.2 and 2005 have in common, so the output
+covers those; version-specific fidelity needs the version packages below. The
+neutral writer also does not emit catalog-group mappings (neither version writer
+does).
+
+### Version-specific writing
+
+For full, version-specific fidelity, implement the `CatalogWriter` interface of
+the target package (`bmecat12` or `bmecat2005`) and hand it to that package's
 `Writer.Do`. See the package documentation
 ([bmecat12](https://pkg.go.dev/github.com/olivere/bmecat/bmecat12),
 [bmecat2005](https://pkg.go.dev/github.com/olivere/bmecat/bmecat2005)) and the

--- a/doc.go
+++ b/doc.go
@@ -37,9 +37,25 @@ in phase 1, mirroring [Reader.DetectVersion]:
 The same value is also surfaced on [Header.Transaction] during Do, for callers
 that read it as part of a full parse.
 
+# Version-neutral writing
+
+[Writer] is the streaming, write-path counterpart of [Reader]: a caller
+implements a [CatalogWriter] (a header plus a channel of products), selects a
+target version with [WithVersion], and Writer emits a valid BMEcat 1.2 or 2005
+document, converting the neutral model to the version-specific one at the
+boundary:
+
+	w := bmecat.NewWriter(out, bmecat.WithVersion(bmecat.Version2005))
+	err := w.Do(ctx, catalog) // catalog implements bmecat.CatalogWriter
+
+As with reading, writing is streaming — each product is converted and encoded as
+it arrives, so even a very large catalog is never held in memory at once — and
+the neutral model carries only the fields the two versions share, so the output
+covers those common fields.
+
 Callers that need raw, version-specific fidelity (including 2005-only fields
-such as PRODUCT_LOGISTIC_DETAILS, or writing catalogs) can use the
-github.com/olivere/bmecat/bmecat12 and github.com/olivere/bmecat/bmecat2005
+such as PRODUCT_LOGISTIC_DETAILS, or writing version-specific elements) can use
+the github.com/olivere/bmecat/bmecat12 and github.com/olivere/bmecat/bmecat2005
 packages directly.
 */
 package bmecat

--- a/example_test.go
+++ b/example_test.go
@@ -74,3 +74,66 @@ func ExampleReader_DetectVersion() {
 	// Output:
 	// version 1.2
 }
+
+// springCatalog is a neutral CatalogWriter: it supplies the header and streams
+// the products. A real implementation would stream from a database or file so
+// the whole catalog is never held in memory; here it ranges over a slice.
+type springCatalog struct{}
+
+func (springCatalog) Header() *bmecat.Header {
+	return &bmecat.Header{
+		Catalog: &bmecat.Catalog{
+			Language: "deu",
+			ID:       "CAT1",
+			Version:  "1.0",
+			Name:     "Spring Catalog",
+		},
+		Supplier: &bmecat.Supplier{Name: "SupplyCo"},
+	}
+}
+
+func (springCatalog) Products(ctx context.Context) (<-chan *bmecat.Product, <-chan error) {
+	products := []*bmecat.Product{
+		{
+			ID:               "1000",
+			GTIN:             "1234567890123",
+			DescriptionShort: "Widget",
+			OrderUnit:        "PCE",
+			Prices: []*bmecat.Price{
+				{Type: "net_customer", Amount: 9.99, Currency: "EUR"},
+			},
+		},
+	}
+	out := make(chan *bmecat.Product)
+	errc := make(chan error, 1)
+	go func() {
+		defer close(out)
+		for _, p := range products {
+			select {
+			case out <- p:
+			case <-ctx.Done():
+				errc <- ctx.Err()
+				return
+			}
+		}
+	}()
+	return out, errc
+}
+
+// ExampleWriter writes a neutral catalog as BMEcat 2005. The same CatalogWriter
+// would produce a 1.2 document with bmecat.WithVersion(bmecat.Version12).
+func ExampleWriter() {
+	var buf strings.Builder
+	w := bmecat.NewWriter(&buf, bmecat.WithVersion(bmecat.Version2005))
+	if err := w.Do(context.Background(), springCatalog{}); err != nil {
+		panic(err)
+	}
+
+	// Read it straight back through the neutral reader to show it round-trips.
+	if err := bmecat.NewReader(strings.NewReader(buf.String())).Do(context.Background(), catalogPrinter{}); err != nil {
+		panic(err)
+	}
+	// Output:
+	// Catalog "Spring Catalog" (BMEcat 2005)
+	// - 1000: Widget (GTIN 1234567890123)
+}

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,143 @@
+package bmecat
+
+import (
+	"context"
+	"io"
+
+	"github.com/olivere/bmecat/bmecat12"
+	"github.com/olivere/bmecat/bmecat2005"
+)
+
+// CatalogWriter is the neutral source of a catalog to write. It mirrors the
+// CatalogWriter interfaces of the bmecat12 and bmecat2005 packages, but deals
+// in the version-neutral types: a caller implements it once and Writer emits
+// either supported version.
+//
+// Products streams the catalog's products and is the reason writing is
+// memory-flat: Writer converts and encodes each product as it arrives, so even
+// a catalog of millions of products is never held in memory at once.
+//
+// The implementation returns a products channel and an error channel. It must:
+//
+//   - close the products channel when all products have been sent;
+//   - to report a failure, send a single non-nil error on the error channel
+//     (which must be buffered, e.g. make(chan error, 1)) before closing the
+//     products channel, then stop;
+//   - select on ctx.Done() while sending, so a canceled context (Writer cancels
+//     it when Do returns) unblocks the producer instead of leaking it.
+//
+// Sending more than one error, or sending the error only after closing the
+// products channel, is a contract violation and may cause the error to be lost.
+type CatalogWriter interface {
+	// Header returns the catalog header, or nil to omit the HEADER element.
+	Header() *Header
+	// Products streams the catalog's products. See the type comment for the
+	// channel contract.
+	Products(ctx context.Context) (<-chan *Product, <-chan error)
+}
+
+// Writer writes a neutral catalog (CatalogWriter) as a BMEcat document of a
+// chosen version. It is the streaming, write-path counterpart of Reader: a
+// caller assembles the neutral types once, picks a target version with
+// WithVersion, and Writer emits a valid BMEcat 1.2 or 2005 document, converting
+// the neutral model to the version-specific one at the boundary.
+//
+// Because the neutral model exposes only the fields 1.2 and 2005 have in common,
+// the output carries those common fields; version-specific fidelity (e.g. 2005
+// PRODUCT_LOGISTIC_DETAILS) requires the bmecat12 / bmecat2005 packages
+// directly. The writer also does not emit catalog-group mappings, mirroring the
+// version writers, which do not write them either.
+type Writer struct {
+	w           io.Writer
+	version     Version
+	transaction Transaction
+	prevVersion int
+	indent      string
+}
+
+// NewWriter creates a Writer over w. By default it emits BMEcat 1.2 with a
+// T_NEW_CATALOG transaction and two-space indentation; override with
+// WithVersion, WithTransaction, WithPreviousVersion and WithIndent.
+func NewWriter(w io.Writer, options ...WriterOption) *Writer {
+	writer := &Writer{
+		w:           w,
+		version:     Version12,
+		transaction: NewCatalog,
+		indent:      "  ",
+	}
+	for _, o := range options {
+		o(writer)
+	}
+	return writer
+}
+
+// WriterOption is the signature of options to pass into NewWriter.
+type WriterOption func(*Writer)
+
+// WithVersion selects the BMEcat version to emit. It defaults to Version12.
+func WithVersion(v Version) WriterOption {
+	return func(w *Writer) {
+		w.version = v
+	}
+}
+
+// WithTransaction selects the document-level transaction to emit. It defaults
+// to NewCatalog.
+func WithTransaction(t Transaction) WriterOption {
+	return func(w *Writer) {
+		w.transaction = t
+	}
+}
+
+// WithPreviousVersion sets the prev_version attribute written on update
+// transactions (T_UPDATE_PRODUCTS / T_UPDATE_PRICES). It is ignored for
+// NewCatalog.
+func WithPreviousVersion(v int) WriterOption {
+	return func(w *Writer) {
+		w.prevVersion = v
+	}
+}
+
+// WithIndent sets the indentation of the emitted XML. It defaults to two
+// spaces; pass the empty string to disable indentation.
+func WithIndent(indent string) WriterOption {
+	return func(w *Writer) {
+		w.indent = indent
+	}
+}
+
+// Do writes the neutral catalog as a BMEcat document of the configured version.
+// It streams products from cw.Products and returns the first error encountered,
+// from the producer or from encoding.
+func (w *Writer) Do(ctx context.Context, cw CatalogWriter) error {
+	// A cancelable context bounds the producer and the conversion bridge: if Do
+	// returns early (e.g. an encoding error), canceling unblocks them so no
+	// goroutine is left waiting on a send.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	switch w.version {
+	case Version2005:
+		return w.writeV2005(ctx, cw)
+	default:
+		return w.writeV12(ctx, cw)
+	}
+}
+
+func (w *Writer) writeV12(ctx context.Context, cw CatalogWriter) error {
+	adapter := &v12CatalogWriter{
+		tx:          transactionToV12(w.transaction),
+		prevVersion: w.prevVersion,
+		neutral:     cw,
+	}
+	return bmecat12.NewWriter(w.w, bmecat12.WithIndent(w.indent)).Do(ctx, adapter)
+}
+
+func (w *Writer) writeV2005(ctx context.Context, cw CatalogWriter) error {
+	adapter := &v2005CatalogWriter{
+		tx:          transactionToV2005(w.transaction),
+		prevVersion: w.prevVersion,
+		neutral:     cw,
+	}
+	return bmecat2005.NewWriter(w.w, bmecat2005.WithIndent(w.indent)).Do(ctx, adapter)
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,293 @@
+package bmecat_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/olivere/bmecat"
+)
+
+func wInt(v int) *int           { return &v }
+func wFloat(v float64) *float64 { return &v }
+
+// sliceCatalogWriter is a test CatalogWriter that streams a fixed header and
+// product slice. Production code streams from its own source; this just adapts a
+// slice for the tests.
+type sliceCatalogWriter struct {
+	header   *bmecat.Header
+	products []*bmecat.Product
+	err      error // if set, sent on the error channel after the products
+}
+
+func (c *sliceCatalogWriter) Header() *bmecat.Header { return c.header }
+
+func (c *sliceCatalogWriter) Products(ctx context.Context) (<-chan *bmecat.Product, <-chan error) {
+	out := make(chan *bmecat.Product)
+	errc := make(chan error, 1)
+	go func() {
+		defer close(out)
+		for _, p := range c.products {
+			select {
+			case out <- p:
+			case <-ctx.Done():
+				errc <- ctx.Err()
+				return
+			}
+		}
+		if c.err != nil {
+			errc <- c.err
+		}
+	}()
+	return out, errc
+}
+
+// fullProduct is a neutral product with every common field populated, so a
+// write→read round-trip exercises the whole conversion and reflect.DeepEqual is
+// meaningful (no nil-vs-empty-slice ambiguity). QuantityMax is left zero because
+// BMEcat 1.2 has no QUANTITY_MAX; it is covered separately.
+func fullProduct() *bmecat.Product {
+	return &bmecat.Product{
+		ID:                      "1000",
+		GTIN:                    "1234567890123",
+		DescriptionShort:        "Widget",
+		DescriptionLong:         "A useful widget.",
+		SupplierAltID:           "ALT-1",
+		ManufacturerID:          "MPN-1",
+		ManufacturerName:        "Acme",
+		ManufacturerTypeDescr:   "Type-X",
+		ERPGroupBuyer:           "EB",
+		ERPGroupSupplier:        "ES",
+		DeliveryTime:            wInt(5),
+		Keywords:                []string{"tool", "widget"},
+		Remarks:                 "handle with care",
+		Segments:                []string{"SEG1"},
+		BuyerIDs:                []*bmecat.TypedValue{{Type: "buyer", Value: "B-1"}},
+		SpecialTreatmentClasses: []*bmecat.TypedValue{{Type: "GGVS", Value: "12"}},
+		Status:                  []*bmecat.TypedValue{{Type: "new", Value: "yes"}},
+		Features: []*bmecat.Features{{
+			SystemName: "ECLASS-5.1",
+			GroupID:    "19010203",
+			Features: []*bmecat.Feature{
+				{Name: "Voltage", Values: []string{"230"}, Unit: "VLT"},
+			},
+		}},
+		OrderUnit:        "PCE",
+		ContentUnit:      "PCE",
+		NoCuPerOu:        1,
+		PriceQuantity:    1,
+		QuantityMin:      1,
+		QuantityInterval: 1,
+		Prices: []*bmecat.Price{{
+			Type:       "net_customer",
+			Amount:     9.99,
+			Currency:   "EUR",
+			Tax:        wFloat(0.19),
+			Factor:     1,
+			LowerBound: 1,
+			Territory:  []string{"DE"},
+		}},
+		Mimes: []*bmecat.Mime{{
+			Type: "image/jpeg", Source: "img.jpg", Descr: "Image", Purpose: "normal", Order: 1,
+		}},
+		UDX: []*bmecat.UDXField{{Name: "SYSTEM.CUSTOM_FIELD1", Value: "A"}},
+	}
+}
+
+func fullHeader() *bmecat.Header {
+	return &bmecat.Header{
+		GeneratorInfo: "Test Generator",
+		Catalog: &bmecat.Catalog{
+			Language:    "deu",
+			ID:          "CAT1",
+			Version:     "1.0",
+			Name:        "Test Catalog",
+			Currency:    "EUR",
+			Territories: []string{"DE", "AT"},
+		},
+		Buyer:    &bmecat.Buyer{ID: "BUYCO", Name: "BuyCo Inc."},
+		Supplier: &bmecat.Supplier{ID: "SUPPLYCO", Name: "SupplyCo Ltd."},
+	}
+}
+
+// TestWriteReadRoundTrip writes a neutral catalog to each version and reads it
+// back through the neutral reader, asserting the common-field model survives the
+// round trip unchanged for both 1.2 and 2005.
+func TestWriteReadRoundTrip(t *testing.T) {
+	for _, version := range []bmecat.Version{bmecat.Version12, bmecat.Version2005} {
+		t.Run(version.String(), func(t *testing.T) {
+			header := fullHeader()
+			product := fullProduct()
+
+			var buf bytes.Buffer
+			cw := &sliceCatalogWriter{header: header, products: []*bmecat.Product{product}}
+			if err := bmecat.NewWriter(&buf, bmecat.WithVersion(version)).Do(context.Background(), cw); err != nil {
+				t.Fatal(err)
+			}
+
+			c := read(t, buf.String())
+
+			// The reader stamps Version, Transaction and the count fields; clear
+			// them so the comparison is against the data we actually wrote.
+			if c.header == nil {
+				t.Fatal("want header, have nil")
+			}
+			if want, have := version, c.header.Version; want != have {
+				t.Errorf("want read-back version %v, have %v", want, have)
+			}
+			if want, have := bmecat.NewCatalog, c.header.Transaction; want != have {
+				t.Errorf("want read-back transaction %v, have %v", want, have)
+			}
+			c.header.Version = 0
+			c.header.Transaction = 0
+			c.header.NumberOfProducts = 0
+			c.header.NumberOfCatalogGroups = 0
+			c.header.NumberOfClassificationGroups = 0
+			if !reflect.DeepEqual(header, c.header) {
+				t.Errorf("header round trip mismatch:\nwant %+v\nhave %+v", header, c.header)
+			}
+
+			if len(c.products) != 1 {
+				t.Fatalf("want one product, have %d", len(c.products))
+			}
+			if !reflect.DeepEqual(product, c.products[0]) {
+				t.Errorf("product round trip mismatch:\nwant %+v\nhave %+v", product, c.products[0])
+			}
+		})
+	}
+}
+
+// TestWriteDefaultVersion confirms the writer emits 1.2 when no version option
+// is given.
+func TestWriteDefaultVersion(t *testing.T) {
+	var buf bytes.Buffer
+	cw := &sliceCatalogWriter{header: fullHeader()}
+	if err := bmecat.NewWriter(&buf).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+	v, err := bmecat.NewReader(bytes.NewReader(buf.Bytes())).DetectVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != bmecat.Version12 {
+		t.Errorf("want default version 1.2, have %v", v)
+	}
+}
+
+// TestWriteTransaction confirms the configured transaction is emitted and reads
+// back via DetectTransaction, including the prev_version attribute on updates.
+func TestWriteTransaction(t *testing.T) {
+	for _, version := range []bmecat.Version{bmecat.Version12, bmecat.Version2005} {
+		t.Run(version.String(), func(t *testing.T) {
+			var buf bytes.Buffer
+			cw := &sliceCatalogWriter{header: fullHeader(), products: []*bmecat.Product{fullProduct()}}
+			w := bmecat.NewWriter(
+				&buf,
+				bmecat.WithVersion(version),
+				bmecat.WithTransaction(bmecat.UpdateProducts),
+				bmecat.WithPreviousVersion(7),
+			)
+			if err := w.Do(context.Background(), cw); err != nil {
+				t.Fatal(err)
+			}
+
+			tx, err := bmecat.NewReader(bytes.NewReader(buf.Bytes())).DetectTransaction()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tx != bmecat.UpdateProducts {
+				t.Errorf("want transaction UpdateProducts, have %v", tx)
+			}
+			if !strings.Contains(buf.String(), `prev_version="7"`) {
+				t.Errorf("want prev_version=\"7\" in output, have:\n%s", buf.String())
+			}
+		})
+	}
+}
+
+// TestWriteQuantityMax confirms QUANTITY_MAX survives a 2005 round trip but is
+// dropped for 1.2, which has no such element.
+func TestWriteQuantityMax(t *testing.T) {
+	tests := []struct {
+		version bmecat.Version
+		want    float64
+	}{
+		{bmecat.Version2005, 99},
+		{bmecat.Version12, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.version.String(), func(t *testing.T) {
+			p := &bmecat.Product{ID: "1", OrderUnit: "PCE", QuantityMax: 99}
+			cw := &sliceCatalogWriter{products: []*bmecat.Product{p}}
+
+			var buf bytes.Buffer
+			if err := bmecat.NewWriter(&buf, bmecat.WithVersion(tt.version)).Do(context.Background(), cw); err != nil {
+				t.Fatal(err)
+			}
+
+			c := read(t, buf.String())
+			if len(c.products) != 1 {
+				t.Fatalf("want one product, have %d", len(c.products))
+			}
+			if have := c.products[0].QuantityMax; have != tt.want {
+				t.Errorf("want QuantityMax %v, have %v", tt.want, have)
+			}
+		})
+	}
+}
+
+// TestWriteStreaming writes many products and reads them back, exercising the
+// streaming bridge across more than one product (and the channel handoff).
+func TestWriteStreaming(t *testing.T) {
+	const n = 1000
+	products := make([]*bmecat.Product, n)
+	for i := range products {
+		products[i] = &bmecat.Product{ID: fmt.Sprintf("P%04d", i), DescriptionShort: "x", OrderUnit: "PCE"}
+	}
+	cw := &sliceCatalogWriter{header: fullHeader(), products: products}
+
+	var buf bytes.Buffer
+	if err := bmecat.NewWriter(&buf, bmecat.WithVersion(bmecat.Version2005)).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+
+	c := read(t, buf.String())
+	if len(c.products) != n {
+		t.Fatalf("want %d products, have %d", n, len(c.products))
+	}
+	if c.products[0].ID != "P0000" || c.products[n-1].ID != fmt.Sprintf("P%04d", n-1) {
+		t.Errorf("product order not preserved: first %q last %q", c.products[0].ID, c.products[n-1].ID)
+	}
+}
+
+// TestWriteProducerError confirms an error from the producer's error channel is
+// returned by Do.
+func TestWriteProducerError(t *testing.T) {
+	boom := errors.New("producer boom")
+	cw := &sliceCatalogWriter{
+		header:   fullHeader(),
+		products: []*bmecat.Product{fullProduct()},
+		err:      boom,
+	}
+	var buf bytes.Buffer
+	err := bmecat.NewWriter(&buf).Do(context.Background(), cw)
+	if !errors.Is(err, boom) {
+		t.Fatalf("want producer error, have %v", err)
+	}
+}
+
+// TestWriteContextCancel confirms a canceled context aborts the write.
+func TestWriteContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cw := &sliceCatalogWriter{header: fullHeader(), products: []*bmecat.Product{fullProduct()}}
+	var buf bytes.Buffer
+	if err := bmecat.NewWriter(&buf).Do(ctx, cw); err == nil {
+		t.Fatal("want error from canceled context, got nil")
+	}
+}

--- a/writer_v12.go
+++ b/writer_v12.go
@@ -1,0 +1,271 @@
+package bmecat
+
+import (
+	"context"
+
+	"github.com/olivere/bmecat/bmecat12"
+)
+
+// transactionToV12 maps the neutral Transaction onto the bmecat12 Transaction.
+// The two enums share the same constants, but converting explicitly keeps the
+// packages decoupled and avoids depending on their iota order matching.
+func transactionToV12(t Transaction) bmecat12.Transaction {
+	switch t {
+	case UpdateProducts:
+		return bmecat12.UpdateProducts
+	case UpdatePrices:
+		return bmecat12.UpdatePrices
+	default:
+		return bmecat12.NewCatalog
+	}
+}
+
+// v12CatalogWriter adapts a neutral CatalogWriter to the bmecat12 CatalogWriter
+// contract that bmecat12.Writer.Do drives, converting each product on the fly.
+type v12CatalogWriter struct {
+	tx          bmecat12.Transaction
+	prevVersion int
+	neutral     CatalogWriter
+}
+
+func (c *v12CatalogWriter) Transaction() bmecat12.Transaction { return c.tx }
+func (c *v12CatalogWriter) PreviousVersion() int              { return c.prevVersion }
+
+func (c *v12CatalogWriter) Header() *bmecat12.Header {
+	return neutralHeaderToV12(c.neutral.Header())
+}
+
+func (c *v12CatalogWriter) Language() string {
+	if h := c.neutral.Header(); h != nil && h.Catalog != nil {
+		return h.Catalog.Language
+	}
+	return ""
+}
+
+// ClassificationSystem returns nil: the neutral model has no classification
+// system, so the neutral writer does not emit CLASSIFICATION_SYSTEM.
+func (c *v12CatalogWriter) ClassificationSystem() *bmecat12.ClassificationSystem { return nil }
+
+// Articles bridges the neutral product stream to the bmecat12 article stream:
+// it reads neutral products from the caller's channel, converts each to a
+// bmecat12.Article, and forwards it, so only one product is in flight at a
+// time. Producer errors and ctx cancellation are propagated.
+func (c *v12CatalogWriter) Articles(ctx context.Context) (<-chan *bmecat12.Article, <-chan error) {
+	out := make(chan *bmecat12.Article)
+	errc := make(chan error, 1)
+
+	src, srcErr := c.neutral.Products(ctx)
+	if src == nil {
+		close(out)
+		return out, errc
+	}
+
+	// out is closed only on clean completion. On an error or cancellation the
+	// goroutine sends to errc and returns with out left open, so the version
+	// writer's select can only proceed via errc — a closed out and a ready errc
+	// are weighed equally by that select, so closing out here would let a clean
+	// EOF win the race and silently swallow the error.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				errc <- ctx.Err()
+				return
+			case err := <-srcErr:
+				if err != nil {
+					errc <- err
+					return
+				}
+				close(out)
+				return
+			case p, ok := <-src:
+				if !ok {
+					// The product channel closed. A producer that closes it via
+					// defer may have sent its error a moment earlier, so check
+					// once more before finishing cleanly.
+					select {
+					case err := <-srcErr:
+						if err != nil {
+							errc <- err
+							return
+						}
+					default:
+					}
+					close(out)
+					return
+				}
+				if p == nil {
+					continue
+				}
+				select {
+				case out <- neutralProductToV12(p):
+				case <-ctx.Done():
+					errc <- ctx.Err()
+					return
+				}
+			}
+		}
+	}()
+	return out, errc
+}
+
+func neutralHeaderToV12(h *Header) *bmecat12.Header {
+	if h == nil {
+		return nil
+	}
+	out := &bmecat12.Header{GeneratorInfo: h.GeneratorInfo}
+	if c := h.Catalog; c != nil {
+		out.Catalog = &bmecat12.Catalog{
+			Language:    c.Language,
+			ID:          c.ID,
+			Version:     c.Version,
+			Name:        c.Name,
+			Currency:    c.Currency,
+			Territories: c.Territories,
+		}
+	}
+	if b := h.Buyer; b != nil {
+		out.Buyer = &bmecat12.Buyer{Name: b.Name}
+		if b.ID != "" {
+			out.Buyer.ID = &bmecat12.IDRef{Value: b.ID}
+		}
+	}
+	if s := h.Supplier; s != nil {
+		out.Supplier = &bmecat12.Supplier{Name: s.Name}
+		if s.ID != "" {
+			out.Supplier.ID = &bmecat12.IDRef{Value: s.ID}
+		}
+	}
+	return out
+}
+
+func neutralProductToV12(p *Product) *bmecat12.Article {
+	a := &bmecat12.Article{
+		Mode:        p.Mode,
+		SupplierAID: p.ID,
+		Details: &bmecat12.ArticleDetails{
+			DescriptionShort:      p.DescriptionShort,
+			DescriptionLong:       p.DescriptionLong,
+			EAN:                   p.GTIN,
+			SupplierAltAID:        p.SupplierAltID,
+			ManufacturerAID:       p.ManufacturerID,
+			ManufacturerName:      p.ManufacturerName,
+			ManufacturerTypeDescr: p.ManufacturerTypeDescr,
+			ERPGroupBuyer:         p.ERPGroupBuyer,
+			ERPGroupSupplier:      p.ERPGroupSupplier,
+			DeliveryTime:          p.DeliveryTime,
+			Keywords:              p.Keywords,
+			Remarks:               p.Remarks,
+			Segments:              p.Segments,
+		},
+	}
+	for _, b := range p.BuyerIDs {
+		a.Details.BuyerAIDs = append(a.Details.BuyerAIDs, &bmecat12.BuyerAID{Type: b.Type, Value: b.Value})
+	}
+	for _, s := range p.SpecialTreatmentClasses {
+		a.Details.SpecialTreatmentClasses = append(a.Details.SpecialTreatmentClasses, &bmecat12.ArticleSpecialTreatmentClass{Type: s.Type, Value: s.Value})
+	}
+	for _, s := range p.Status {
+		a.Details.ArticleStatus = append(a.Details.ArticleStatus, &bmecat12.ArticleStatus{Type: s.Type, Value: s.Value})
+	}
+	if od := neutralOrderDetailsToV12(p); od != nil {
+		a.OrderDetails = od
+	}
+	for _, f := range p.Features {
+		a.Features = append(a.Features, neutralFeaturesToV12(f))
+	}
+	if prices := neutralPricesToV12(p.Prices); prices != nil {
+		a.PriceDetails = []*bmecat12.ArticlePriceDetails{{Prices: prices}}
+	}
+	if mi := neutralMimesToV12(p.Mimes); mi != nil {
+		a.MimeInfo = mi
+	}
+	if udx := neutralUDXToV12(p.UDX); udx != nil {
+		a.UDX = udx
+	}
+	return a
+}
+
+// neutralOrderDetailsToV12 returns the ARTICLE_ORDER_DETAILS for a product, or
+// nil when the product carries no order detail (so the reader's nil-guarded
+// round-trip is preserved). QuantityMax has no 1.2 element and is dropped.
+func neutralOrderDetailsToV12(p *Product) *bmecat12.ArticleOrderDetails {
+	if p.OrderUnit == "" && p.ContentUnit == "" && p.NoCuPerOu == 0 &&
+		p.PriceQuantity == 0 && p.QuantityMin == 0 && p.QuantityInterval == 0 {
+		return nil
+	}
+	return &bmecat12.ArticleOrderDetails{
+		OrderUnit:        p.OrderUnit,
+		ContentUnit:      p.ContentUnit,
+		NoCuPerOu:        p.NoCuPerOu,
+		PriceQuantity:    p.PriceQuantity,
+		QuantityMin:      p.QuantityMin,
+		QuantityInterval: p.QuantityInterval,
+	}
+}
+
+func neutralFeaturesToV12(f *Features) *bmecat12.ArticleFeatures {
+	if f == nil {
+		return nil
+	}
+	out := &bmecat12.ArticleFeatures{
+		FeatureSystemName: f.SystemName,
+		FeatureGroupID:    f.GroupID,
+		FeatureGroupName:  f.GroupName,
+	}
+	for _, ft := range f.Features {
+		out.Features = append(out.Features, &bmecat12.Feature{
+			Name:   ft.Name,
+			Values: ft.Values,
+			Unit:   ft.Unit,
+		})
+	}
+	return out
+}
+
+func neutralPricesToV12(prices []*Price) []*bmecat12.ArticlePrice {
+	if len(prices) == 0 {
+		return nil
+	}
+	out := make([]*bmecat12.ArticlePrice, 0, len(prices))
+	for _, p := range prices {
+		out = append(out, &bmecat12.ArticlePrice{
+			Type:       p.Type,
+			Amount:     p.Amount,
+			Currency:   p.Currency,
+			Tax:        p.Tax,
+			Factor:     p.Factor,
+			LowerBound: p.LowerBound,
+			Territory:  p.Territory,
+		})
+	}
+	return out
+}
+
+func neutralMimesToV12(mimes []*Mime) *bmecat12.MimeInfo {
+	if len(mimes) == 0 {
+		return nil
+	}
+	mi := &bmecat12.MimeInfo{}
+	for _, m := range mimes {
+		mi.Mimes = append(mi.Mimes, &bmecat12.Mime{
+			Type:    m.Type,
+			Source:  m.Source,
+			Descr:   m.Descr,
+			Purpose: m.Purpose,
+			Order:   m.Order,
+		})
+	}
+	return mi
+}
+
+func neutralUDXToV12(fields []*UDXField) *bmecat12.UserDefinedExtensions {
+	if len(fields) == 0 {
+		return nil
+	}
+	udx := &bmecat12.UserDefinedExtensions{}
+	for _, f := range fields {
+		udx.Fields.Add(f.Name, f.Value)
+	}
+	return udx
+}

--- a/writer_v2005.go
+++ b/writer_v2005.go
@@ -1,0 +1,278 @@
+package bmecat
+
+import (
+	"context"
+
+	"github.com/olivere/bmecat/bmecat2005"
+)
+
+// transactionToV2005 maps the neutral Transaction onto the bmecat2005
+// Transaction. As with transactionToV12, the conversion is explicit so the
+// packages stay decoupled from each other's iota order.
+func transactionToV2005(t Transaction) bmecat2005.Transaction {
+	switch t {
+	case UpdateProducts:
+		return bmecat2005.UpdateProducts
+	case UpdatePrices:
+		return bmecat2005.UpdatePrices
+	default:
+		return bmecat2005.NewCatalog
+	}
+}
+
+// v2005CatalogWriter adapts a neutral CatalogWriter to the bmecat2005
+// CatalogWriter contract that bmecat2005.Writer.Do drives, converting each
+// product on the fly.
+type v2005CatalogWriter struct {
+	tx          bmecat2005.Transaction
+	prevVersion int
+	neutral     CatalogWriter
+}
+
+func (c *v2005CatalogWriter) Transaction() bmecat2005.Transaction { return c.tx }
+func (c *v2005CatalogWriter) PreviousVersion() int                { return c.prevVersion }
+
+func (c *v2005CatalogWriter) Header() *bmecat2005.Header {
+	return neutralHeaderToV2005(c.neutral.Header())
+}
+
+func (c *v2005CatalogWriter) Language() string {
+	if h := c.neutral.Header(); h != nil && h.Catalog != nil {
+		return h.Catalog.Language
+	}
+	return ""
+}
+
+// ClassificationSystem returns nil: the neutral model has no classification
+// system, so the neutral writer does not emit CLASSIFICATION_SYSTEM.
+func (c *v2005CatalogWriter) ClassificationSystem() *bmecat2005.ClassificationSystem { return nil }
+
+// Products bridges the neutral product stream to the bmecat2005 product stream:
+// it reads neutral products from the caller's channel, converts each to a
+// bmecat2005.Product, and forwards it, so only one product is in flight at a
+// time. Producer errors and ctx cancellation are propagated.
+func (c *v2005CatalogWriter) Products(ctx context.Context) (<-chan *bmecat2005.Product, <-chan error) {
+	out := make(chan *bmecat2005.Product)
+	errc := make(chan error, 1)
+
+	src, srcErr := c.neutral.Products(ctx)
+	if src == nil {
+		close(out)
+		return out, errc
+	}
+
+	// out is closed only on clean completion. On an error or cancellation the
+	// goroutine sends to errc and returns with out left open, so the version
+	// writer's select can only proceed via errc — a closed out and a ready errc
+	// are weighed equally by that select, so closing out here would let a clean
+	// EOF win the race and silently swallow the error.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				errc <- ctx.Err()
+				return
+			case err := <-srcErr:
+				if err != nil {
+					errc <- err
+					return
+				}
+				close(out)
+				return
+			case p, ok := <-src:
+				if !ok {
+					// The product channel closed. A producer that closes it via
+					// defer may have sent its error a moment earlier, so check
+					// once more before finishing cleanly.
+					select {
+					case err := <-srcErr:
+						if err != nil {
+							errc <- err
+							return
+						}
+					default:
+					}
+					close(out)
+					return
+				}
+				if p == nil {
+					continue
+				}
+				select {
+				case out <- neutralProductToV2005(p):
+				case <-ctx.Done():
+					errc <- ctx.Err()
+					return
+				}
+			}
+		}
+	}()
+	return out, errc
+}
+
+func neutralHeaderToV2005(h *Header) *bmecat2005.Header {
+	if h == nil {
+		return nil
+	}
+	out := &bmecat2005.Header{GeneratorInfo: h.GeneratorInfo}
+	if c := h.Catalog; c != nil {
+		out.Catalog = &bmecat2005.Catalog{
+			Language:    c.Language,
+			ID:          c.ID,
+			Version:     c.Version,
+			Name:        c.Name,
+			Currency:    c.Currency,
+			Territories: c.Territories,
+		}
+	}
+	if b := h.Buyer; b != nil {
+		out.Buyer = &bmecat2005.Buyer{Name: b.Name}
+		if b.ID != "" {
+			out.Buyer.ID = &bmecat2005.IDRef{Value: b.ID}
+		}
+	}
+	if s := h.Supplier; s != nil {
+		out.Supplier = &bmecat2005.Supplier{Name: s.Name}
+		if s.ID != "" {
+			out.Supplier.ID = &bmecat2005.IDRef{Value: s.ID}
+		}
+	}
+	return out
+}
+
+func neutralProductToV2005(p *Product) *bmecat2005.Product {
+	prod := &bmecat2005.Product{
+		Mode:        p.Mode,
+		SupplierPID: p.ID,
+		Details: &bmecat2005.ProductDetails{
+			DescriptionShort:      p.DescriptionShort,
+			DescriptionLong:       p.DescriptionLong,
+			SupplierAltPID:        p.SupplierAltID,
+			ManufacturerPID:       p.ManufacturerID,
+			ManufacturerName:      p.ManufacturerName,
+			ManufacturerTypeDescr: p.ManufacturerTypeDescr,
+			ERPGroupBuyer:         p.ERPGroupBuyer,
+			ERPGroupSupplier:      p.ERPGroupSupplier,
+			DeliveryTime:          p.DeliveryTime,
+			Keywords:              p.Keywords,
+			Remarks:               p.Remarks,
+			Segments:              p.Segments,
+		},
+	}
+	// GTIN maps to INTERNATIONAL_PID (the 2005 replacement for EAN); the reader
+	// reads it back from the first INTERNATIONAL_PID.
+	if p.GTIN != "" {
+		prod.Details.InternationalPIDs = []*bmecat2005.InternationalPID{{Type: "gtin", Value: p.GTIN}}
+	}
+	for _, b := range p.BuyerIDs {
+		prod.Details.BuyerPIDs = append(prod.Details.BuyerPIDs, &bmecat2005.BuyerPID{Type: b.Type, Value: b.Value})
+	}
+	for _, s := range p.SpecialTreatmentClasses {
+		prod.Details.SpecialTreatmentClasses = append(prod.Details.SpecialTreatmentClasses, &bmecat2005.ProductSpecialTreatmentClass{Type: s.Type, Value: s.Value})
+	}
+	for _, s := range p.Status {
+		prod.Details.ProductStatus = append(prod.Details.ProductStatus, &bmecat2005.ProductStatus{Type: s.Type, Value: s.Value})
+	}
+	if od := neutralOrderDetailsToV2005(p); od != nil {
+		prod.OrderDetails = od
+	}
+	for _, f := range p.Features {
+		prod.Features = append(prod.Features, neutralFeaturesToV2005(f))
+	}
+	if prices := neutralPricesToV2005(p.Prices); prices != nil {
+		prod.PriceDetails = []*bmecat2005.ProductPriceDetails{{Prices: prices}}
+	}
+	if mi := neutralMimesToV2005(p.Mimes); mi != nil {
+		prod.MimeInfo = mi
+	}
+	if udx := neutralUDXToV2005(p.UDX); udx != nil {
+		prod.UDX = udx
+	}
+	return prod
+}
+
+// neutralOrderDetailsToV2005 returns the PRODUCT_ORDER_DETAILS for a product,
+// or nil when the product carries no order detail. Unlike 1.2, 2005 has
+// QUANTITY_MAX, so QuantityMax is carried here.
+func neutralOrderDetailsToV2005(p *Product) *bmecat2005.ProductOrderDetails {
+	if p.OrderUnit == "" && p.ContentUnit == "" && p.NoCuPerOu == 0 &&
+		p.PriceQuantity == 0 && p.QuantityMin == 0 && p.QuantityInterval == 0 &&
+		p.QuantityMax == 0 {
+		return nil
+	}
+	return &bmecat2005.ProductOrderDetails{
+		OrderUnit:        p.OrderUnit,
+		ContentUnit:      p.ContentUnit,
+		NoCuPerOu:        p.NoCuPerOu,
+		PriceQuantity:    p.PriceQuantity,
+		QuantityMin:      p.QuantityMin,
+		QuantityInterval: p.QuantityInterval,
+		QuantityMax:      p.QuantityMax,
+	}
+}
+
+func neutralFeaturesToV2005(f *Features) *bmecat2005.ProductFeatures {
+	if f == nil {
+		return nil
+	}
+	out := &bmecat2005.ProductFeatures{
+		FeatureSystemName: f.SystemName,
+		FeatureGroupID:    f.GroupID,
+		FeatureGroupName:  f.GroupName,
+	}
+	for _, ft := range f.Features {
+		out.Features = append(out.Features, &bmecat2005.Feature{
+			Name:   ft.Name,
+			Values: ft.Values,
+			Unit:   ft.Unit,
+		})
+	}
+	return out
+}
+
+func neutralPricesToV2005(prices []*Price) []*bmecat2005.ProductPrice {
+	if len(prices) == 0 {
+		return nil
+	}
+	out := make([]*bmecat2005.ProductPrice, 0, len(prices))
+	for _, p := range prices {
+		out = append(out, &bmecat2005.ProductPrice{
+			Type:       p.Type,
+			Amount:     p.Amount,
+			Currency:   p.Currency,
+			Tax:        p.Tax,
+			Factor:     p.Factor,
+			LowerBound: p.LowerBound,
+			Territory:  p.Territory,
+		})
+	}
+	return out
+}
+
+func neutralMimesToV2005(mimes []*Mime) *bmecat2005.MimeInfo {
+	if len(mimes) == 0 {
+		return nil
+	}
+	mi := &bmecat2005.MimeInfo{}
+	for _, m := range mimes {
+		mi.Mimes = append(mi.Mimes, &bmecat2005.Mime{
+			Type:    m.Type,
+			Source:  m.Source,
+			Descr:   m.Descr,
+			Purpose: m.Purpose,
+			Order:   m.Order,
+		})
+	}
+	return mi
+}
+
+func neutralUDXToV2005(fields []*UDXField) *bmecat2005.UserDefinedExtensions {
+	if len(fields) == 0 {
+		return nil
+	}
+	udx := &bmecat2005.UserDefinedExtensions{}
+	for _, f := range fields {
+		udx.Fields.Add(f.Name, f.Value)
+	}
+	return udx
+}


### PR DESCRIPTION
Closes #31.

Adds `bmecat.Writer`, the streaming write-path counterpart of `bmecat.Reader`. A caller implements the neutral `CatalogWriter` (a header plus a channel of products), picks a target version with `WithVersion`, and the writer emits a valid BMEcat 1.2 or 2005 document — converting the neutral model to the version-specific one at the boundary, and the neutral `Transaction` to the per-version enum. This removes the need to drop down to `bmecat12`/`bmecat2005` just to write a catalog, and resolves the three-way `Transaction` enum duplication noted in #31.

## API

```go
type CatalogWriter interface {
	Header() *Header
	Products(ctx context.Context) (<-chan *Product, <-chan error)
}

w := bmecat.NewWriter(out, bmecat.WithVersion(bmecat.Version2005))
err := w.Do(ctx, catalog) // catalog implements bmecat.CatalogWriter
```

Options: `WithVersion` (default 1.2), `WithTransaction` (default `NewCatalog`), `WithPreviousVersion`, `WithIndent`.

## Streaming, not buffering

The writer mirrors the version writers' channel model and streams end-to-end: `Do` runs a bridge goroutine that pulls one neutral product, converts it (the inverse of the reader's adapters), and hands it to the version writer — one product in flight at a time, O(1) memory regardless of catalog size. (A slice-based API was prototyped first but rejected: at ~10M products it would peak at tens of GB.) `Do` wraps the context in a cancelable one so early return unblocks both the bridge and the caller's producer.

## Why channel-based

It matches the existing `bmecat12`/`bmecat2005` `CatalogWriter` interfaces and preserves the library's streaming, low-memory property (the slice API would have been the only buffering component in an otherwise-streaming library). The error-channel contract (buffered cap-1, error sent before closing the products channel, at most one) is documented on the interface.

## Coverage / fidelity

The neutral model carries the fields 1.2 and 2005 have in common, so output covers those; `QuantityMax` is emitted only for 2005, `GTIN` maps to `EAN` (1.2) / `INTERNATIONAL_PID` (2005). Catalog-group mappings are not emitted — neither version writer emits them either.

## Tests

`writer_test.go`: write→read round-trip for both versions (full `reflect.DeepEqual`), default version, transaction + `prev_version`, `QuantityMax` (2005-only), 1000-product streaming, producer-error propagation, and context cancellation. Plus a streaming `ExampleWriter`.

Two error-propagation bugs were found and fixed during development (the bridge must not close the output channel on the error path, since the version writer's select weighs closed-data and ready-error equally; and a non-blocking error drain when the products channel closes). The writer tests pass under `-race` at high `-count`.

All green: `go build`, `go vet`, `gofumpt -l`, `staticcheck`, and `go test -race -tags integration ./...`.