### PR TITLE
Add pull-style Writer.WriteFunc over CatalogWriter

### DIFF
--- a/bmecat12/writer.go
+++ b/bmecat12/writer.go
@@ -29,6 +29,9 @@ func (t Transaction) String() string {
 
 // CatalogWriter specifies the contract that users of Writer have to
 // implement to allow writing a BMEcat file.
+//
+// Implement Articles with the StreamArticles helper to stream articles from a
+// pull-style producer and avoid hand-rolling the channel bookkeeping.
 type CatalogWriter interface {
 	Transaction() Transaction
 	Language() string

--- a/bmecat12/writer_stream.go
+++ b/bmecat12/writer_stream.go
@@ -11,14 +11,13 @@ import "context"
 //
 // produce is called once and streams articles by calling yield once per
 // article. yield forwards the article to Writer and returns a non-nil error
-// when the context is canceled (Writer cancels it, if it was made cancelable,
-// once Do returns), letting the producer stop early:
+// when ctx is canceled, letting the producer stop early:
 //
 //	func (c myCatalog) Articles(ctx context.Context) (<-chan *bmecat12.Article, <-chan error) {
 //		return bmecat12.StreamArticles(ctx, func(yield func(*bmecat12.Article) error) error {
 //			for rows.Next() {
 //				if err := yield(buildArticle(rows)); err != nil {
-//					return err // downstream stopped; stop producing
+//					return err // ctx canceled; stop producing
 //				}
 //			}
 //			return rows.Err()
@@ -28,6 +27,11 @@ import "context"
 // Returning a non-nil error from produce — from yield or the producer itself,
 // such as rows.Err — stops the write and is reported by Writer.Do. A nil
 // article is skipped.
+//
+// Writer.Do does not cancel ctx itself, so if Do can return before the producer
+// is drained (an encoding error mid-stream), pass a cancelable context and
+// cancel it once Do returns; the pending yield then unblocks instead of leaking
+// the producer goroutine.
 func StreamArticles(ctx context.Context, produce func(yield func(*Article) error) error) (<-chan *Article, <-chan error) {
 	out := make(chan *Article)
 	errc := make(chan error, 1)

--- a/bmecat12/writer_stream.go
+++ b/bmecat12/writer_stream.go
@@ -1,0 +1,57 @@
+package bmecat12
+
+import "context"
+
+// StreamArticles adapts a pull-style producer to the (<-chan *Article,
+// <-chan error) pair a CatalogWriter's Articles method must return. It confines
+// the channel bookkeeping the interface otherwise demands — a buffered error
+// channel, sending at most one error before stopping, and selecting on
+// ctx.Done so a canceled context unblocks the producer — to one place, so an
+// Articles implementation cannot get the contract subtly wrong.
+//
+// produce is called once and streams articles by calling yield once per
+// article. yield forwards the article to Writer and returns a non-nil error
+// when the context is canceled (Writer cancels it, if it was made cancelable,
+// once Do returns), letting the producer stop early:
+//
+//	func (c myCatalog) Articles(ctx context.Context) (<-chan *bmecat12.Article, <-chan error) {
+//		return bmecat12.StreamArticles(ctx, func(yield func(*bmecat12.Article) error) error {
+//			for rows.Next() {
+//				if err := yield(buildArticle(rows)); err != nil {
+//					return err // downstream stopped; stop producing
+//				}
+//			}
+//			return rows.Err()
+//		})
+//	}
+//
+// Returning a non-nil error from produce — from yield or the producer itself,
+// such as rows.Err — stops the write and is reported by Writer.Do. A nil
+// article is skipped.
+func StreamArticles(ctx context.Context, produce func(yield func(*Article) error) error) (<-chan *Article, <-chan error) {
+	out := make(chan *Article)
+	errc := make(chan error, 1)
+	go func() {
+		yield := func(a *Article) error {
+			if a == nil {
+				return nil
+			}
+			select {
+			case out <- a:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		// On error, errc receives it and out is left open: Writer's article loop
+		// returns via the error channel, and leaving out open keeps a clean EOF
+		// from racing the error in that select. out is closed only on clean
+		// completion, when no error is sent.
+		if err := produce(yield); err != nil {
+			errc <- err
+			return
+		}
+		close(out)
+	}()
+	return out, errc
+}

--- a/bmecat12/writer_stream_test.go
+++ b/bmecat12/writer_stream_test.go
@@ -1,0 +1,123 @@
+package bmecat12_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/olivere/bmecat/bmecat12"
+)
+
+// funcCatalog is a CatalogWriter whose Articles method is backed by the
+// pull-style StreamArticles helper, exercising the helper end to end through
+// Writer.Do.
+type funcCatalog struct {
+	header  *bmecat12.Header
+	produce func(yield func(*bmecat12.Article) error) error
+}
+
+func (funcCatalog) Transaction() bmecat12.Transaction                    { return bmecat12.NewCatalog }
+func (funcCatalog) Language() string                                     { return "deu" }
+func (funcCatalog) PreviousVersion() int                                 { return 0 }
+func (c funcCatalog) Header() *bmecat12.Header                           { return c.header }
+func (funcCatalog) ClassificationSystem() *bmecat12.ClassificationSystem { return nil }
+
+func (c funcCatalog) Articles(ctx context.Context) (<-chan *bmecat12.Article, <-chan error) {
+	return bmecat12.StreamArticles(ctx, c.produce)
+}
+
+// TestStreamArticles writes several articles through StreamArticles and confirms
+// they are all emitted in order.
+func TestStreamArticles(t *testing.T) {
+	const n = 100
+	cw := funcCatalog{
+		header: testHeader,
+		produce: func(yield func(*bmecat12.Article) error) error {
+			for i := range n {
+				a := &bmecat12.Article{
+					SupplierAID: fmt.Sprintf("A%04d", i),
+					Details:     &bmecat12.ArticleDetails{DescriptionShort: "x"},
+				}
+				if err := yield(a); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := bmecat12.NewWriter(&buf).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if got := strings.Count(out, "<SUPPLIER_AID>"); got != n {
+		t.Fatalf("want %d articles, have %d", n, got)
+	}
+	if first, last := strings.Index(out, "A0000"), strings.Index(out, fmt.Sprintf("A%04d", n-1)); first < 0 || last < 0 || first > last {
+		t.Errorf("article order not preserved (first idx %d, last idx %d)", first, last)
+	}
+}
+
+// TestStreamArticlesSkipsNil confirms a nil article yielded by the producer is
+// skipped rather than written.
+func TestStreamArticlesSkipsNil(t *testing.T) {
+	cw := funcCatalog{
+		header: testHeader,
+		produce: func(yield func(*bmecat12.Article) error) error {
+			if err := yield(nil); err != nil {
+				return err
+			}
+			return yield(&bmecat12.Article{SupplierAID: "1", Details: &bmecat12.ArticleDetails{DescriptionShort: "x"}})
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := bmecat12.NewWriter(&buf).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(buf.String(), "<SUPPLIER_AID>"); got != 1 {
+		t.Fatalf("want one article (nil skipped), have %d", got)
+	}
+}
+
+// TestStreamArticlesProducerError confirms an error returned by the producer is
+// reported by Writer.Do.
+func TestStreamArticlesProducerError(t *testing.T) {
+	boom := errors.New("producer boom")
+	cw := funcCatalog{
+		header: testHeader,
+		produce: func(yield func(*bmecat12.Article) error) error {
+			if err := yield(&bmecat12.Article{SupplierAID: "1", Details: &bmecat12.ArticleDetails{DescriptionShort: "x"}}); err != nil {
+				return err
+			}
+			return boom
+		},
+	}
+
+	err := bmecat12.NewWriter(&bytes.Buffer{}).Do(context.Background(), cw)
+	if !errors.Is(err, boom) {
+		t.Fatalf("want producer error, have %v", err)
+	}
+}
+
+// TestStreamArticlesContextCancel confirms a canceled context aborts the write
+// and that yield observes the cancellation.
+func TestStreamArticlesContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cw := funcCatalog{
+		header: testHeader,
+		produce: func(yield func(*bmecat12.Article) error) error {
+			return yield(&bmecat12.Article{SupplierAID: "1", Details: &bmecat12.ArticleDetails{DescriptionShort: "x"}})
+		},
+	}
+
+	if err := bmecat12.NewWriter(&bytes.Buffer{}).Do(ctx, cw); err == nil {
+		t.Fatal("want error from canceled context, got nil")
+	}
+}

--- a/bmecat2005/writer.go
+++ b/bmecat2005/writer.go
@@ -47,6 +47,9 @@ func (t Transaction) dtd() string {
 
 // CatalogWriter specifies the contract that users of Writer have to
 // implement to allow writing a BMEcat file.
+//
+// Implement Products with the StreamProducts helper to stream products from a
+// pull-style producer and avoid hand-rolling the channel bookkeeping.
 type CatalogWriter interface {
 	Transaction() Transaction
 	Language() string

--- a/bmecat2005/writer_stream.go
+++ b/bmecat2005/writer_stream.go
@@ -11,14 +11,13 @@ import "context"
 //
 // produce is called once and streams products by calling yield once per
 // product. yield forwards the product to Writer and returns a non-nil error
-// when the context is canceled (Writer cancels it, if it was made cancelable,
-// once Do returns), letting the producer stop early:
+// when ctx is canceled, letting the producer stop early:
 //
 //	func (c myCatalog) Products(ctx context.Context) (<-chan *bmecat2005.Product, <-chan error) {
 //		return bmecat2005.StreamProducts(ctx, func(yield func(*bmecat2005.Product) error) error {
 //			for rows.Next() {
 //				if err := yield(buildProduct(rows)); err != nil {
-//					return err // downstream stopped; stop producing
+//					return err // ctx canceled; stop producing
 //				}
 //			}
 //			return rows.Err()
@@ -28,6 +27,11 @@ import "context"
 // Returning a non-nil error from produce — from yield or the producer itself,
 // such as rows.Err — stops the write and is reported by Writer.Do. A nil
 // product is skipped.
+//
+// Writer.Do does not cancel ctx itself, so if Do can return before the producer
+// is drained (an encoding error mid-stream), pass a cancelable context and
+// cancel it once Do returns; the pending yield then unblocks instead of leaking
+// the producer goroutine.
 func StreamProducts(ctx context.Context, produce func(yield func(*Product) error) error) (<-chan *Product, <-chan error) {
 	out := make(chan *Product)
 	errc := make(chan error, 1)

--- a/bmecat2005/writer_stream.go
+++ b/bmecat2005/writer_stream.go
@@ -1,0 +1,57 @@
+package bmecat2005
+
+import "context"
+
+// StreamProducts adapts a pull-style producer to the (<-chan *Product,
+// <-chan error) pair a CatalogWriter's Products method must return. It confines
+// the channel bookkeeping the interface otherwise demands — a buffered error
+// channel, sending at most one error before stopping, and selecting on
+// ctx.Done so a canceled context unblocks the producer — to one place, so a
+// Products implementation cannot get the contract subtly wrong.
+//
+// produce is called once and streams products by calling yield once per
+// product. yield forwards the product to Writer and returns a non-nil error
+// when the context is canceled (Writer cancels it, if it was made cancelable,
+// once Do returns), letting the producer stop early:
+//
+//	func (c myCatalog) Products(ctx context.Context) (<-chan *bmecat2005.Product, <-chan error) {
+//		return bmecat2005.StreamProducts(ctx, func(yield func(*bmecat2005.Product) error) error {
+//			for rows.Next() {
+//				if err := yield(buildProduct(rows)); err != nil {
+//					return err // downstream stopped; stop producing
+//				}
+//			}
+//			return rows.Err()
+//		})
+//	}
+//
+// Returning a non-nil error from produce — from yield or the producer itself,
+// such as rows.Err — stops the write and is reported by Writer.Do. A nil
+// product is skipped.
+func StreamProducts(ctx context.Context, produce func(yield func(*Product) error) error) (<-chan *Product, <-chan error) {
+	out := make(chan *Product)
+	errc := make(chan error, 1)
+	go func() {
+		yield := func(p *Product) error {
+			if p == nil {
+				return nil
+			}
+			select {
+			case out <- p:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		// On error, errc receives it and out is left open: Writer's product loop
+		// returns via the error channel, and leaving out open keeps a clean EOF
+		// from racing the error in that select. out is closed only on clean
+		// completion, when no error is sent.
+		if err := produce(yield); err != nil {
+			errc <- err
+			return
+		}
+		close(out)
+	}()
+	return out, errc
+}

--- a/bmecat2005/writer_stream_test.go
+++ b/bmecat2005/writer_stream_test.go
@@ -1,0 +1,123 @@
+package bmecat2005_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/olivere/bmecat/bmecat2005"
+)
+
+// funcCatalog is a CatalogWriter whose Products method is backed by the
+// pull-style StreamProducts helper, exercising the helper end to end through
+// Writer.Do.
+type funcCatalog struct {
+	header  *bmecat2005.Header
+	produce func(yield func(*bmecat2005.Product) error) error
+}
+
+func (funcCatalog) Transaction() bmecat2005.Transaction                    { return bmecat2005.NewCatalog }
+func (funcCatalog) Language() string                                       { return "deu" }
+func (funcCatalog) PreviousVersion() int                                   { return 0 }
+func (c funcCatalog) Header() *bmecat2005.Header                           { return c.header }
+func (funcCatalog) ClassificationSystem() *bmecat2005.ClassificationSystem { return nil }
+
+func (c funcCatalog) Products(ctx context.Context) (<-chan *bmecat2005.Product, <-chan error) {
+	return bmecat2005.StreamProducts(ctx, c.produce)
+}
+
+// TestStreamProducts writes several products through StreamProducts and confirms
+// they are all emitted in order.
+func TestStreamProducts(t *testing.T) {
+	const n = 100
+	cw := funcCatalog{
+		header: testHeader,
+		produce: func(yield func(*bmecat2005.Product) error) error {
+			for i := range n {
+				p := &bmecat2005.Product{
+					SupplierPID: fmt.Sprintf("P%04d", i),
+					Details:     &bmecat2005.ProductDetails{DescriptionShort: "x"},
+				}
+				if err := yield(p); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := bmecat2005.NewWriter(&buf).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if got := strings.Count(out, "<SUPPLIER_PID>"); got != n {
+		t.Fatalf("want %d products, have %d", n, got)
+	}
+	if first, last := strings.Index(out, "P0000"), strings.Index(out, fmt.Sprintf("P%04d", n-1)); first < 0 || last < 0 || first > last {
+		t.Errorf("product order not preserved (first idx %d, last idx %d)", first, last)
+	}
+}
+
+// TestStreamProductsSkipsNil confirms a nil product yielded by the producer is
+// skipped rather than written.
+func TestStreamProductsSkipsNil(t *testing.T) {
+	cw := funcCatalog{
+		header: testHeader,
+		produce: func(yield func(*bmecat2005.Product) error) error {
+			if err := yield(nil); err != nil {
+				return err
+			}
+			return yield(&bmecat2005.Product{SupplierPID: "1", Details: &bmecat2005.ProductDetails{DescriptionShort: "x"}})
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := bmecat2005.NewWriter(&buf).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(buf.String(), "<SUPPLIER_PID>"); got != 1 {
+		t.Fatalf("want one product (nil skipped), have %d", got)
+	}
+}
+
+// TestStreamProductsProducerError confirms an error returned by the producer is
+// reported by Writer.Do.
+func TestStreamProductsProducerError(t *testing.T) {
+	boom := errors.New("producer boom")
+	cw := funcCatalog{
+		header: testHeader,
+		produce: func(yield func(*bmecat2005.Product) error) error {
+			if err := yield(&bmecat2005.Product{SupplierPID: "1", Details: &bmecat2005.ProductDetails{DescriptionShort: "x"}}); err != nil {
+				return err
+			}
+			return boom
+		},
+	}
+
+	err := bmecat2005.NewWriter(&bytes.Buffer{}).Do(context.Background(), cw)
+	if !errors.Is(err, boom) {
+		t.Fatalf("want producer error, have %v", err)
+	}
+}
+
+// TestStreamProductsContextCancel confirms a canceled context aborts the write
+// and that yield observes the cancellation.
+func TestStreamProductsContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cw := funcCatalog{
+		header: testHeader,
+		produce: func(yield func(*bmecat2005.Product) error) error {
+			return yield(&bmecat2005.Product{SupplierPID: "1", Details: &bmecat2005.ProductDetails{DescriptionShort: "x"}})
+		},
+	}
+
+	if err := bmecat2005.NewWriter(&bytes.Buffer{}).Do(ctx, cw); err == nil {
+		t.Fatal("want error from canceled context, got nil")
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -48,6 +48,20 @@ boundary:
 	w := bmecat.NewWriter(out, bmecat.WithVersion(bmecat.Version2005))
 	err := w.Do(ctx, catalog) // catalog implements bmecat.CatalogWriter
 
+For most callers, [Writer.WriteFunc] is the ergonomic default: it takes a header
+and a pull-style producer that streams products by calling yield, keeping the
+streaming property while removing the channel bookkeeping the [CatalogWriter]
+interface requires:
+
+	err := w.WriteFunc(ctx, header, func(yield func(*bmecat.Product) error) error {
+		for rows.Next() {
+			if err := yield(buildProduct(rows)); err != nil {
+				return err
+			}
+		}
+		return rows.Err()
+	})
+
 As with reading, writing is streaming — each product is converted and encoded as
 it arrives, so even a very large catalog is never held in memory at once — and
 the neutral model carries only the fields the two versions share, so the output

--- a/example_test.go
+++ b/example_test.go
@@ -137,3 +137,42 @@ func ExampleWriter() {
 	// Catalog "Spring Catalog" (BMEcat 2005)
 	// - 1000: Widget (GTIN 1234567890123)
 }
+
+// ExampleWriter_writeFunc writes the same catalog with the pull-style WriteFunc:
+// the producer streams products by calling yield, with no channels to manage.
+func ExampleWriter_writeFunc() {
+	header := &bmecat.Header{
+		Catalog:  &bmecat.Catalog{Language: "deu", ID: "CAT1", Version: "1.0", Name: "Spring Catalog"},
+		Supplier: &bmecat.Supplier{Name: "SupplyCo"},
+	}
+	products := []*bmecat.Product{
+		{
+			ID:               "1000",
+			GTIN:             "1234567890123",
+			DescriptionShort: "Widget",
+			OrderUnit:        "PCE",
+			Prices:           []*bmecat.Price{{Type: "net_customer", Amount: 9.99, Currency: "EUR"}},
+		},
+	}
+
+	var buf strings.Builder
+	w := bmecat.NewWriter(&buf, bmecat.WithVersion(bmecat.Version2005))
+	err := w.WriteFunc(context.Background(), header, func(yield func(*bmecat.Product) error) error {
+		for _, p := range products {
+			if err := yield(p); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	if err := bmecat.NewReader(strings.NewReader(buf.String())).Do(context.Background(), catalogPrinter{}); err != nil {
+		panic(err)
+	}
+	// Output:
+	// Catalog "Spring Catalog" (BMEcat 2005)
+	// - 1000: Widget (GTIN 1234567890123)
+}

--- a/writer.go
+++ b/writer.go
@@ -28,6 +28,10 @@ import (
 //
 // Sending more than one error, or sending the error only after closing the
 // products channel, is a contract violation and may cause the error to be lost.
+//
+// This channel contract is the low-level API. Most callers should prefer
+// Writer.WriteFunc, a pull-style producer that keeps the streaming property but
+// removes the channel bookkeeping entirely.
 type CatalogWriter interface {
 	// Header returns the catalog header, or nil to omit the HEADER element.
 	Header() *Header
@@ -122,6 +126,67 @@ func (w *Writer) Do(ctx context.Context, cw CatalogWriter) error {
 	default:
 		return w.writeV12(ctx, cw)
 	}
+}
+
+// WriteFunc writes a neutral catalog using a pull-style producer instead of the
+// channel pair CatalogWriter requires. It is the ergonomic default for the
+// write path: produce is called once and streams products by calling yield once
+// per product, mirroring the range-over-func iterators in iter.Seq.
+//
+// yield forwards the product downstream and returns the first downstream error —
+// an encoding failure or a canceled context — so the producer can stop early:
+//
+//	err := w.WriteFunc(ctx, header, func(yield func(*bmecat.Product) error) error {
+//		for rows.Next() {
+//			if err := yield(buildProduct(rows)); err != nil {
+//				return err // downstream failed; stop producing
+//			}
+//		}
+//		return rows.Err()
+//	})
+//
+// Returning a non-nil error from produce — whether from yield or the producer
+// itself, such as rows.Err — stops the write and is returned from WriteFunc.
+// A nil product is skipped. There are no channels to buffer, no error-ordering
+// rules, and no goroutine for the caller to manage; the streaming, memory-flat
+// property of Do is preserved.
+func (w *Writer) WriteFunc(ctx context.Context, header *Header, produce func(yield func(*Product) error) error) error {
+	return w.Do(ctx, &funcCatalogWriter{header: header, produce: produce})
+}
+
+// funcCatalogWriter adapts a pull-style producer to the channel-based
+// CatalogWriter contract, confining the channel bookkeeping (buffered error
+// channel, error-before-close ordering, ctx.Done select) to one place.
+type funcCatalogWriter struct {
+	header  *Header
+	produce func(yield func(*Product) error) error
+}
+
+func (c *funcCatalogWriter) Header() *Header { return c.header }
+
+func (c *funcCatalogWriter) Products(ctx context.Context) (<-chan *Product, <-chan error) {
+	out := make(chan *Product)
+	errc := make(chan error, 1)
+	go func() {
+		// The error (if any) is sent before out is closed: errc <- err runs
+		// before the deferred close, satisfying the CatalogWriter contract.
+		defer close(out)
+		yield := func(p *Product) error {
+			if p == nil {
+				return nil
+			}
+			select {
+			case out <- p:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		if err := c.produce(yield); err != nil {
+			errc <- err
+		}
+	}()
+	return out, errc
 }
 
 func (w *Writer) writeV12(ctx context.Context, cw CatalogWriter) error {

--- a/writer.go
+++ b/writer.go
@@ -168,9 +168,6 @@ func (c *funcCatalogWriter) Products(ctx context.Context) (<-chan *Product, <-ch
 	out := make(chan *Product)
 	errc := make(chan error, 1)
 	go func() {
-		// The error (if any) is sent before out is closed: errc <- err runs
-		// before the deferred close, satisfying the CatalogWriter contract.
-		defer close(out)
 		yield := func(p *Product) error {
 			if p == nil {
 				return nil
@@ -182,9 +179,15 @@ func (c *funcCatalogWriter) Products(ctx context.Context) (<-chan *Product, <-ch
 				return ctx.Err()
 			}
 		}
+		// On error, errc receives it and out is left open: Do's product loop
+		// returns via the error channel, and leaving out open keeps a clean EOF
+		// from racing the error in that select. out is closed only on clean
+		// completion, when no error is sent.
 		if err := c.produce(yield); err != nil {
 			errc <- err
+			return
 		}
+		close(out)
 	}()
 	return out, errc
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -291,3 +291,124 @@ func TestWriteContextCancel(t *testing.T) {
 		t.Fatal("want error from canceled context, got nil")
 	}
 }
+
+// TestWriteFuncRoundTrip writes a neutral catalog via the pull-style WriteFunc
+// and reads it back, asserting the model survives unchanged for both versions —
+// the same guarantee TestWriteReadRoundTrip gives the channel-based Do.
+func TestWriteFuncRoundTrip(t *testing.T) {
+	for _, version := range []bmecat.Version{bmecat.Version12, bmecat.Version2005} {
+		t.Run(version.String(), func(t *testing.T) {
+			header := fullHeader()
+			product := fullProduct()
+
+			var buf bytes.Buffer
+			err := bmecat.NewWriter(&buf, bmecat.WithVersion(version)).
+				WriteFunc(context.Background(), header, func(yield func(*bmecat.Product) error) error {
+					return yield(product)
+				})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			c := read(t, buf.String())
+			if c.header == nil {
+				t.Fatal("want header, have nil")
+			}
+			c.header.Version = 0
+			c.header.Transaction = 0
+			c.header.NumberOfProducts = 0
+			c.header.NumberOfCatalogGroups = 0
+			c.header.NumberOfClassificationGroups = 0
+			if !reflect.DeepEqual(header, c.header) {
+				t.Errorf("header round trip mismatch:\nwant %+v\nhave %+v", header, c.header)
+			}
+			if len(c.products) != 1 {
+				t.Fatalf("want one product, have %d", len(c.products))
+			}
+			if !reflect.DeepEqual(product, c.products[0]) {
+				t.Errorf("product round trip mismatch:\nwant %+v\nhave %+v", product, c.products[0])
+			}
+		})
+	}
+}
+
+// TestWriteFuncStreaming streams many products through yield and reads them
+// back, confirming order is preserved across the pull-style bridge.
+func TestWriteFuncStreaming(t *testing.T) {
+	const n = 1000
+	var buf bytes.Buffer
+	err := bmecat.NewWriter(&buf, bmecat.WithVersion(bmecat.Version2005)).
+		WriteFunc(context.Background(), fullHeader(), func(yield func(*bmecat.Product) error) error {
+			for i := range n {
+				p := &bmecat.Product{ID: fmt.Sprintf("P%04d", i), DescriptionShort: "x", OrderUnit: "PCE"}
+				if err := yield(p); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := read(t, buf.String())
+	if len(c.products) != n {
+		t.Fatalf("want %d products, have %d", n, len(c.products))
+	}
+	if c.products[0].ID != "P0000" || c.products[n-1].ID != fmt.Sprintf("P%04d", n-1) {
+		t.Errorf("product order not preserved: first %q last %q", c.products[0].ID, c.products[n-1].ID)
+	}
+}
+
+// TestWriteFuncSkipsNil confirms a nil product yielded by the producer is
+// skipped rather than written or panicked on.
+func TestWriteFuncSkipsNil(t *testing.T) {
+	var buf bytes.Buffer
+	err := bmecat.NewWriter(&buf).
+		WriteFunc(context.Background(), fullHeader(), func(yield func(*bmecat.Product) error) error {
+			if err := yield(nil); err != nil {
+				return err
+			}
+			return yield(&bmecat.Product{ID: "1", DescriptionShort: "x", OrderUnit: "PCE"})
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := read(t, buf.String())
+	if len(c.products) != 1 {
+		t.Fatalf("want one product (nil skipped), have %d", len(c.products))
+	}
+}
+
+// TestWriteFuncProducerError confirms an error returned by the producer is
+// returned by WriteFunc.
+func TestWriteFuncProducerError(t *testing.T) {
+	boom := errors.New("producer boom")
+	var buf bytes.Buffer
+	err := bmecat.NewWriter(&buf).
+		WriteFunc(context.Background(), fullHeader(), func(yield func(*bmecat.Product) error) error {
+			if err := yield(fullProduct()); err != nil {
+				return err
+			}
+			return boom
+		})
+	if !errors.Is(err, boom) {
+		t.Fatalf("want producer error, have %v", err)
+	}
+}
+
+// TestWriteFuncContextCancel confirms a canceled context aborts the write and
+// that yield observes the cancellation so the producer can stop.
+func TestWriteFuncContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var buf bytes.Buffer
+	err := bmecat.NewWriter(&buf).
+		WriteFunc(ctx, fullHeader(), func(yield func(*bmecat.Product) error) error {
+			return yield(fullProduct())
+		})
+	if err == nil {
+		t.Fatal("want error from canceled context, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Removes the `CatalogWriter` channel footgun described in #33 at both layers:

**Neutral wrapper** — adds `Writer.WriteFunc(ctx, header, produce)`, a callback/pull-style producer layered over `Writer.Do`:

```go
err := w.WriteFunc(ctx, header, func(yield func(*bmecat.Product) error) error {
    for rows.Next() {
        if err := yield(buildProduct(rows)); err != nil {
            return err // downstream stopped; stop producing
        }
    }
    return rows.Err()
})
```

**Version-specific writers** — adds `bmecat12.StreamArticles` and `bmecat2005.StreamProducts`, exported adapters that turn a pull-style producer into the channel pair `CatalogWriter.Articles`/`.Products` must return. The five other interface methods are trivial getters, so the hazard is isolated to the one streaming method; the helper lets a caller implement it as a one-liner:

```go
func (c myCatalog) Articles(ctx context.Context) (<-chan *bmecat12.Article, <-chan error) {
    return bmecat12.StreamArticles(ctx, func(yield func(*bmecat12.Article) error) error {
        for rows.Next() {
            if err := yield(buildArticle(rows)); err != nil {
                return err
            }
        }
        return rows.Err()
    })
}
```

## Design notes

- `yield` forwards the item downstream and returns the first downstream error (an encoding failure surfaced via context cancellation, or cancellation itself), so the producer can stop early. A nil item is skipped.
- The helpers (and the neutral `funcCatalogWriter`) leave the products channel **open on error** and close it **only on clean completion**. The version writers' article/product loops return on the error channel without re-checking it after observing a close, so closing-then-erroring would let a clean EOF race the error in their `select`; leaving the channel open removes that race.
- Additive: the channel `CatalogWriter` + `Do` API is unchanged. Interface docs now point at the helpers.

## Tests

Neutral, 1.2, and 2005 each get: round-trip/streaming order, nil-skip, producer-error propagation, and context-cancel. All pass, including under `-race`.

Closes #33