### PR TITLE
Expose price validity dates and price-details grouping on neutral model

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ func main() {
 
 The neutral model exposes the fields 1.2 and 2005 share; in particular
 `Product.GTIN` unifies the 1.2 `EAN` and 2005 `INTERNATIONAL_PID` elements.
-Runnable examples are in the
+Prices come both flattened (`Product.Prices`) and grouped by their
+`ARTICLE_PRICE_DETAILS` / `PRODUCT_PRICE_DETAILS` wrapper with validity dates
+(`Product.PriceDetails`), so you can pick the currently-valid block or spot a
+price calendar. Runnable examples are in the
 [package documentation](https://pkg.go.dev/github.com/olivere/bmecat#pkg-examples).
 
 To gate on the document-level transaction — for example to accept only full

--- a/adapter_v12.go
+++ b/adapter_v12.go
@@ -2,6 +2,7 @@ package bmecat
 
 import (
 	"io"
+	"time"
 
 	"github.com/olivere/bmecat/bmecat12"
 )
@@ -190,17 +191,12 @@ func convertV12Product(a *bmecat12.Article) *Product {
 		out.Features = append(out.Features, convertV12Features(f))
 	}
 	for _, pd := range a.PriceDetails {
-		for _, p := range pd.Prices {
-			out.Prices = append(out.Prices, &Price{
-				Type:       p.Type,
-				Amount:     p.Amount,
-				Currency:   p.Currency,
-				Tax:        p.Tax,
-				Factor:     p.Factor,
-				LowerBound: p.LowerBound,
-				Territory:  p.Territory,
-			})
+		npd := convertV12PriceDetails(pd)
+		if npd == nil {
+			continue
 		}
+		out.PriceDetails = append(out.PriceDetails, npd)
+		out.Prices = append(out.Prices, npd.Prices...)
 	}
 	if mi := a.MimeInfo; mi != nil {
 		for _, m := range mi.Mimes {
@@ -214,6 +210,50 @@ func convertV12Product(a *bmecat12.Article) *Product {
 		}
 	}
 	return out
+}
+
+func convertV12PriceDetails(pd *bmecat12.ArticlePriceDetails) *PriceDetails {
+	if pd == nil {
+		return nil
+	}
+	out := &PriceDetails{
+		ValidStart:   v12ValidDate(pd.Dates, bmecat12.DateTimeValidStartDate),
+		ValidEnd:     v12ValidDate(pd.Dates, bmecat12.DateTimeValidEndDate),
+		IsDailyPrice: pd.IsDailyPrice(),
+	}
+	for _, p := range pd.Prices {
+		if p == nil {
+			continue
+		}
+		out.Prices = append(out.Prices, &Price{
+			Type:       p.Type,
+			Amount:     p.Amount,
+			Currency:   p.Currency,
+			Tax:        p.Tax,
+			Factor:     p.Factor,
+			LowerBound: p.LowerBound,
+			Territory:  p.Territory,
+		})
+	}
+	return out
+}
+
+// v12ValidDate returns the parsed value of the first DATETIME of the given type,
+// or nil when it is absent or unparseable. Unlike ArticlePriceDetails'
+// ValidStartDate/ValidEndDate, it does not substitute a sentinel default, so the
+// neutral model can distinguish "no date" from a real bound.
+func v12ValidDate(dates []*bmecat12.DateTime, typ string) *time.Time {
+	for _, d := range dates {
+		if d == nil || d.Type != typ {
+			continue
+		}
+		t, err := d.Time()
+		if err != nil {
+			return nil
+		}
+		return &t
+	}
+	return nil
 }
 
 func convertV12Features(f *bmecat12.ArticleFeatures) *Features {

--- a/adapter_v2005.go
+++ b/adapter_v2005.go
@@ -1,6 +1,10 @@
 package bmecat
 
-import "github.com/olivere/bmecat/bmecat2005"
+import (
+	"time"
+
+	"github.com/olivere/bmecat/bmecat2005"
+)
 
 // v2005Adapter implements the bmecat2005 handler interfaces, converts each
 // version-specific element into the neutral type, and forwards it to the
@@ -176,17 +180,12 @@ func convertV2005Product(p *bmecat2005.Product) *Product {
 		out.Features = append(out.Features, convertV2005Features(f))
 	}
 	for _, pd := range p.PriceDetails {
-		for _, pr := range pd.Prices {
-			out.Prices = append(out.Prices, &Price{
-				Type:       pr.Type,
-				Amount:     pr.Amount,
-				Currency:   pr.Currency,
-				Tax:        taxFromV2005Price(pr),
-				Factor:     pr.Factor,
-				LowerBound: pr.LowerBound,
-				Territory:  pr.Territory,
-			})
+		npd := convertV2005PriceDetails(pd)
+		if npd == nil {
+			continue
 		}
+		out.PriceDetails = append(out.PriceDetails, npd)
+		out.Prices = append(out.Prices, npd.Prices...)
 	}
 	if mi := p.MimeInfo; mi != nil {
 		for _, m := range mi.Mimes {
@@ -200,6 +199,50 @@ func convertV2005Product(p *bmecat2005.Product) *Product {
 		}
 	}
 	return out
+}
+
+func convertV2005PriceDetails(pd *bmecat2005.ProductPriceDetails) *PriceDetails {
+	if pd == nil {
+		return nil
+	}
+	out := &PriceDetails{
+		ValidStart:   v2005ValidDate(pd.Dates, bmecat2005.DateTimeValidStartDate),
+		ValidEnd:     v2005ValidDate(pd.Dates, bmecat2005.DateTimeValidEndDate),
+		IsDailyPrice: pd.IsDailyPrice(),
+	}
+	for _, pr := range pd.Prices {
+		if pr == nil {
+			continue
+		}
+		out.Prices = append(out.Prices, &Price{
+			Type:       pr.Type,
+			Amount:     pr.Amount,
+			Currency:   pr.Currency,
+			Tax:        taxFromV2005Price(pr),
+			Factor:     pr.Factor,
+			LowerBound: pr.LowerBound,
+			Territory:  pr.Territory,
+		})
+	}
+	return out
+}
+
+// v2005ValidDate returns the parsed value of the first DATETIME of the given
+// type, or nil when it is absent or unparseable. Unlike ProductPriceDetails'
+// ValidStartDate/ValidEndDate, it does not substitute a sentinel default, so the
+// neutral model can distinguish "no date" from a real bound.
+func v2005ValidDate(dates []*bmecat2005.DateTime, typ string) *time.Time {
+	for _, d := range dates {
+		if d == nil || d.Type != typ {
+			continue
+		}
+		t, err := d.Time()
+		if err != nil {
+			return nil
+		}
+		return &t
+	}
+	return nil
 }
 
 // taxFromV2005Price returns the tax rate for a 2005 price: the bare TAX

--- a/doc.go
+++ b/doc.go
@@ -23,6 +23,14 @@ The neutral model exposes the fields the two versions have in common. In
 particular [Product.GTIN] unifies the 1.2 EAN element and the 2005
 INTERNATIONAL_PID element behind a single accessor.
 
+Prices are exposed two ways. [Product.Prices] is a flat list of every price
+block, convenient when the grouping does not matter. [Product.PriceDetails]
+preserves the ARTICLE_PRICE_DETAILS / PRODUCT_PRICE_DETAILS wrapper grouping,
+including each wrapper's validity dates ([PriceDetails.ValidStart] /
+[PriceDetails.ValidEnd], nil when the source omits them) — so a consumer can
+pick the currently-valid block or detect a price calendar (several dated
+wrappers).
+
 A caller that needs to gate on the document-level transaction — for example to
 reject incremental updates and only accept full catalogs — can detect it cheaply
 in phase 1, mirroring [Reader.DetectVersion]:

--- a/model.go
+++ b/model.go
@@ -2,6 +2,7 @@ package bmecat
 
 import (
 	"strings"
+	"time"
 	"unicode/utf8"
 )
 
@@ -172,8 +173,17 @@ type Product struct {
 	// always zero, because 1.2 has no QUANTITY_MAX element.
 	QuantityMax float64
 
+	// Prices is the flattened list of every price block across all
+	// PriceDetails wrappers, in document order. It is a convenience view that
+	// loses the wrapper boundary and validity dates; consumers that need those
+	// should read PriceDetails instead.
 	Prices []*Price
-	Mimes  []*Mime
+	// PriceDetails preserves the ARTICLE_PRICE_DETAILS (1.2) /
+	// PRODUCT_PRICE_DETAILS (2005) wrapper grouping, including each wrapper's
+	// validity dates. Use it to pick the currently-valid block or to detect
+	// price calendars (several dated wrappers).
+	PriceDetails []*PriceDetails
+	Mimes        []*Mime
 
 	// UDX carries USER_DEFINED_EXTENSIONS as neutral name/value pairs. Callers
 	// that need raw or nested UDX XML should read the bmecat12/bmecat2005
@@ -246,6 +256,25 @@ type Price struct {
 	Factor     float64
 	LowerBound float64
 	Territory  []string
+}
+
+// PriceDetails is the version-neutral view of an ARTICLE_PRICE_DETAILS (1.2) /
+// PRODUCT_PRICE_DETAILS (2005) wrapper. It groups one or more Prices that share
+// a validity window, preserving the wrapper boundary that Product.Prices
+// flattens away.
+type PriceDetails struct {
+	// ValidStart and ValidEnd are the wrapper's validity dates, read from its
+	// valid_start_date / valid_end_date DATETIME entries. They are nil when the
+	// source document omits the date; unlike the version-specific
+	// ValidStartDate/ValidEndDate accessors, no sentinel default is substituted,
+	// so a consumer can distinguish "no date" from a real bound.
+	ValidStart *time.Time
+	ValidEnd   *time.Time
+	// IsDailyPrice reports whether the wrapper is flagged as a daily price
+	// (DAILY_PRICE).
+	IsDailyPrice bool
+	// Prices are the price blocks grouped under this wrapper.
+	Prices []*Price
 }
 
 // Mime is the version-neutral view of a MIME element.

--- a/price_details_test.go
+++ b/price_details_test.go
@@ -1,0 +1,205 @@
+package bmecat_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/olivere/bmecat"
+)
+
+// catalog12PriceDetails and catalog2005PriceDetails carry the same product with
+// two ARTICLE_PRICE_DETAILS / PRODUCT_PRICE_DETAILS wrappers: a dated, graduated
+// block valid for the first half of 2020, and a daily-price block valid from
+// mid-2020 with no end date.
+const catalog12PriceDetails = `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="1.2">
+  <HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER>
+  <T_NEW_CATALOG>
+    <ARTICLE>
+      <SUPPLIER_AID>1000</SUPPLIER_AID>
+      <ARTICLE_DETAILS><DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT></ARTICLE_DETAILS>
+      <ARTICLE_PRICE_DETAILS>
+        <DATETIME type="valid_start_date"><DATE>2020-01-01</DATE></DATETIME>
+        <DATETIME type="valid_end_date"><DATE>2020-06-30</DATE></DATETIME>
+        <ARTICLE_PRICE price_type="net_list">
+          <PRICE_AMOUNT>10</PRICE_AMOUNT><PRICE_CURRENCY>EUR</PRICE_CURRENCY><LOWER_BOUND>1</LOWER_BOUND>
+        </ARTICLE_PRICE>
+        <ARTICLE_PRICE price_type="net_list">
+          <PRICE_AMOUNT>8</PRICE_AMOUNT><PRICE_CURRENCY>EUR</PRICE_CURRENCY><LOWER_BOUND>100</LOWER_BOUND>
+        </ARTICLE_PRICE>
+      </ARTICLE_PRICE_DETAILS>
+      <ARTICLE_PRICE_DETAILS>
+        <DATETIME type="valid_start_date"><DATE>2020-07-01</DATE></DATETIME>
+        <DAILY_PRICE>true</DAILY_PRICE>
+        <ARTICLE_PRICE price_type="net_list">
+          <PRICE_AMOUNT>12</PRICE_AMOUNT><PRICE_CURRENCY>EUR</PRICE_CURRENCY>
+        </ARTICLE_PRICE>
+      </ARTICLE_PRICE_DETAILS>
+    </ARTICLE>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+const catalog2005PriceDetails = `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="2005" xmlns="http://www.bmecat.org/bmecat/2005">
+  <HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER>
+  <T_NEW_CATALOG>
+    <PRODUCT>
+      <SUPPLIER_PID>1000</SUPPLIER_PID>
+      <PRODUCT_DETAILS><DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT></PRODUCT_DETAILS>
+      <PRODUCT_PRICE_DETAILS>
+        <DATETIME type="valid_start_date"><DATE>2020-01-01</DATE></DATETIME>
+        <DATETIME type="valid_end_date"><DATE>2020-06-30</DATE></DATETIME>
+        <PRODUCT_PRICE price_type="net_list">
+          <PRICE_AMOUNT>10</PRICE_AMOUNT><PRICE_CURRENCY>EUR</PRICE_CURRENCY><LOWER_BOUND>1</LOWER_BOUND>
+        </PRODUCT_PRICE>
+        <PRODUCT_PRICE price_type="net_list">
+          <PRICE_AMOUNT>8</PRICE_AMOUNT><PRICE_CURRENCY>EUR</PRICE_CURRENCY><LOWER_BOUND>100</LOWER_BOUND>
+        </PRODUCT_PRICE>
+      </PRODUCT_PRICE_DETAILS>
+      <PRODUCT_PRICE_DETAILS>
+        <DATETIME type="valid_start_date"><DATE>2020-07-01</DATE></DATETIME>
+        <DAILY_PRICE>true</DAILY_PRICE>
+        <PRODUCT_PRICE price_type="net_list">
+          <PRICE_AMOUNT>12</PRICE_AMOUNT><PRICE_CURRENCY>EUR</PRICE_CURRENCY>
+        </PRODUCT_PRICE>
+      </PRODUCT_PRICE_DETAILS>
+    </PRODUCT>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+// TestReadPriceDetails covers issue #36: the neutral read model preserves the
+// price-details wrapper grouping and each wrapper's validity dates, distinguishes
+// an absent date (nil) from a real bound, and still exposes the flattened Prices.
+func TestReadPriceDetails(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		doc  string
+	}{
+		{"1.2", catalog12PriceDetails},
+		{"2005", catalog2005PriceDetails},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := read(t, tt.doc)
+			if len(c.products) != 1 {
+				t.Fatalf("want one product, have %d", len(c.products))
+			}
+			p := c.products[0]
+
+			// Flattened convenience view spans both wrappers.
+			if want, have := 3, len(p.Prices); want != have {
+				t.Fatalf("len(Prices) = %d, want %d", have, want)
+			}
+
+			// Wrapper grouping is preserved.
+			if want, have := 2, len(p.PriceDetails); want != have {
+				t.Fatalf("len(PriceDetails) = %d, want %d", have, want)
+			}
+
+			// First wrapper: dated, graduated, not a daily price.
+			first := p.PriceDetails[0]
+			wantStart := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+			wantEnd := time.Date(2020, 6, 30, 0, 0, 0, 0, time.UTC)
+			if first.ValidStart == nil || !first.ValidStart.Equal(wantStart) {
+				t.Errorf("PriceDetails[0].ValidStart = %v, want %v", first.ValidStart, wantStart)
+			}
+			if first.ValidEnd == nil || !first.ValidEnd.Equal(wantEnd) {
+				t.Errorf("PriceDetails[0].ValidEnd = %v, want %v", first.ValidEnd, wantEnd)
+			}
+			if first.IsDailyPrice {
+				t.Errorf("PriceDetails[0].IsDailyPrice = true, want false")
+			}
+			if want, have := 2, len(first.Prices); want != have {
+				t.Errorf("PriceDetails[0] len(Prices) = %d, want %d", have, want)
+			}
+
+			// Second wrapper: open-ended (no end date) and a daily price.
+			second := p.PriceDetails[1]
+			wantStart2 := time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC)
+			if second.ValidStart == nil || !second.ValidStart.Equal(wantStart2) {
+				t.Errorf("PriceDetails[1].ValidStart = %v, want %v", second.ValidStart, wantStart2)
+			}
+			if second.ValidEnd != nil {
+				t.Errorf("PriceDetails[1].ValidEnd = %v, want nil (absent date)", second.ValidEnd)
+			}
+			if !second.IsDailyPrice {
+				t.Errorf("PriceDetails[1].IsDailyPrice = false, want true")
+			}
+			if want, have := 1, len(second.Prices); want != have {
+				t.Errorf("PriceDetails[1] len(Prices) = %d, want %d", have, want)
+			}
+		})
+	}
+}
+
+// TestPriceDetailsRoundTrip writes a product carrying two dated price-details
+// wrappers and reads it back, asserting the grouping, validity dates and daily
+// flag survive the round trip for both versions.
+func TestPriceDetailsRoundTrip(t *testing.T) {
+	start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2020, 6, 30, 0, 0, 0, 0, time.UTC)
+	start2 := time.Date(2020, 7, 1, 0, 0, 0, 0, time.UTC)
+
+	product := &bmecat.Product{
+		ID:               "1000",
+		DescriptionShort: "Widget",
+		PriceDetails: []*bmecat.PriceDetails{
+			{
+				ValidStart: &start,
+				ValidEnd:   &end,
+				Prices: []*bmecat.Price{
+					{Type: "net_list", Amount: 10, Currency: "EUR", LowerBound: 1},
+					{Type: "net_list", Amount: 8, Currency: "EUR", LowerBound: 100},
+				},
+			},
+			{
+				ValidStart:   &start2,
+				IsDailyPrice: true,
+				Prices: []*bmecat.Price{
+					{Type: "net_list", Amount: 12, Currency: "EUR"},
+				},
+			},
+		},
+	}
+
+	for _, version := range []bmecat.Version{bmecat.Version12, bmecat.Version2005} {
+		t.Run(version.String(), func(t *testing.T) {
+			var buf bytes.Buffer
+			cw := &sliceCatalogWriter{header: fullHeader(), products: []*bmecat.Product{product}}
+			if err := bmecat.NewWriter(&buf, bmecat.WithVersion(version)).Do(context.Background(), cw); err != nil {
+				t.Fatal(err)
+			}
+
+			c := read(t, buf.String())
+			if len(c.products) != 1 {
+				t.Fatalf("want one product, have %d", len(c.products))
+			}
+			if !reflect.DeepEqual(product.PriceDetails, c.products[0].PriceDetails) {
+				t.Errorf("PriceDetails round trip mismatch:\nwant %s\nhave %s",
+					formatPriceDetails(product.PriceDetails), formatPriceDetails(c.products[0].PriceDetails))
+			}
+		})
+	}
+}
+
+// formatPriceDetails renders PriceDetails for readable test failures, since the
+// default %+v prints the validity-date pointers as addresses.
+func formatPriceDetails(pds []*bmecat.PriceDetails) string {
+	var b strings.Builder
+	for i, pd := range pds {
+		fmt.Fprintf(&b, "[%d] start=%s end=%s daily=%t prices=%d ",
+			i, formatTimePtr(pd.ValidStart), formatTimePtr(pd.ValidEnd), pd.IsDailyPrice, len(pd.Prices))
+	}
+	return b.String()
+}
+
+func formatTimePtr(t *time.Time) string {
+	if t == nil {
+		return "<nil>"
+	}
+	return t.Format("2006-01-02")
+}

--- a/writer.go
+++ b/writer.go
@@ -209,3 +209,12 @@ func (w *Writer) writeV2005(ctx context.Context, cw CatalogWriter) error {
 	}
 	return bmecat2005.NewWriter(w.w, bmecat2005.WithIndent(w.indent)).Do(ctx, adapter)
 }
+
+// dailyPriceString renders a neutral PriceDetails.IsDailyPrice flag onto the
+// DAILY_PRICE element value, returning "" (omitted) when the flag is unset.
+func dailyPriceString(daily bool) string {
+	if daily {
+		return "true"
+	}
+	return ""
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -51,6 +51,18 @@ func (c *sliceCatalogWriter) Products(ctx context.Context) (<-chan *bmecat.Produ
 // meaningful (no nil-vs-empty-slice ambiguity). QuantityMax is left zero because
 // BMEcat 1.2 has no QUANTITY_MAX; it is covered separately.
 func fullProduct() *bmecat.Product {
+	// price is shared between the flattened Prices view and the PriceDetails
+	// wrapper so a write→read round trip reproduces both: the reader rebuilds
+	// Prices by flattening the wrappers it reads back.
+	price := &bmecat.Price{
+		Type:       "net_customer",
+		Amount:     9.99,
+		Currency:   "EUR",
+		Tax:        wFloat(0.19),
+		Factor:     1,
+		LowerBound: 1,
+		Territory:  []string{"DE"},
+	}
 	return &bmecat.Product{
 		ID:                      "1000",
 		GTIN:                    "1234567890123",
@@ -82,15 +94,8 @@ func fullProduct() *bmecat.Product {
 		PriceQuantity:    1,
 		QuantityMin:      1,
 		QuantityInterval: 1,
-		Prices: []*bmecat.Price{{
-			Type:       "net_customer",
-			Amount:     9.99,
-			Currency:   "EUR",
-			Tax:        wFloat(0.19),
-			Factor:     1,
-			LowerBound: 1,
-			Territory:  []string{"DE"},
-		}},
+		Prices:           []*bmecat.Price{price},
+		PriceDetails:     []*bmecat.PriceDetails{{Prices: []*bmecat.Price{price}}},
 		Mimes: []*bmecat.Mime{{
 			Type: "image/jpeg", Source: "img.jpg", Descr: "Image", Purpose: "normal", Order: 1,
 		}},

--- a/writer_v12.go
+++ b/writer_v12.go
@@ -174,9 +174,7 @@ func neutralProductToV12(p *Product) *bmecat12.Article {
 	for _, f := range p.Features {
 		a.Features = append(a.Features, neutralFeaturesToV12(f))
 	}
-	if prices := neutralPricesToV12(p.Prices); prices != nil {
-		a.PriceDetails = []*bmecat12.ArticlePriceDetails{{Prices: prices}}
-	}
+	a.PriceDetails = neutralPriceDetailsToV12(p)
 	if mi := neutralMimesToV12(p.Mimes); mi != nil {
 		a.MimeInfo = mi
 	}
@@ -221,6 +219,49 @@ func neutralFeaturesToV12(f *Features) *bmecat12.ArticleFeatures {
 		})
 	}
 	return out
+}
+
+// neutralPriceDetailsToV12 builds the ARTICLE_PRICE_DETAILS wrappers for a
+// product. When the product carries PriceDetails it emits one wrapper per
+// entry, preserving validity dates and grouping; otherwise it falls back to the
+// flattened Prices in a single wrapper, so callers that only set Prices keep
+// the previous behavior. It returns nil when the product has no prices at all.
+func neutralPriceDetailsToV12(p *Product) []*bmecat12.ArticlePriceDetails {
+	if len(p.PriceDetails) > 0 {
+		var out []*bmecat12.ArticlePriceDetails
+		for _, pd := range p.PriceDetails {
+			if pd == nil {
+				continue
+			}
+			out = append(out, &bmecat12.ArticlePriceDetails{
+				Dates:            validDatesToV12(pd),
+				DailyPriceString: dailyPriceString(pd.IsDailyPrice),
+				Prices:           neutralPricesToV12(pd.Prices),
+			})
+		}
+		return out
+	}
+	if prices := neutralPricesToV12(p.Prices); prices != nil {
+		return []*bmecat12.ArticlePriceDetails{{Prices: prices}}
+	}
+	return nil
+}
+
+// validDatesToV12 builds the DATETIME entries for a wrapper's validity dates,
+// omitting any that are unset.
+func validDatesToV12(pd *PriceDetails) []*bmecat12.DateTime {
+	var dates []*bmecat12.DateTime
+	if pd.ValidStart != nil {
+		if dt := bmecat12.NewDateTime(bmecat12.DateTimeValidStartDate, *pd.ValidStart); dt != nil {
+			dates = append(dates, dt)
+		}
+	}
+	if pd.ValidEnd != nil {
+		if dt := bmecat12.NewDateTime(bmecat12.DateTimeValidEndDate, *pd.ValidEnd); dt != nil {
+			dates = append(dates, dt)
+		}
+	}
+	return dates
 }
 
 func neutralPricesToV12(prices []*Price) []*bmecat12.ArticlePrice {

--- a/writer_v2005.go
+++ b/writer_v2005.go
@@ -179,9 +179,7 @@ func neutralProductToV2005(p *Product) *bmecat2005.Product {
 	for _, f := range p.Features {
 		prod.Features = append(prod.Features, neutralFeaturesToV2005(f))
 	}
-	if prices := neutralPricesToV2005(p.Prices); prices != nil {
-		prod.PriceDetails = []*bmecat2005.ProductPriceDetails{{Prices: prices}}
-	}
+	prod.PriceDetails = neutralPriceDetailsToV2005(p)
 	if mi := neutralMimesToV2005(p.Mimes); mi != nil {
 		prod.MimeInfo = mi
 	}
@@ -228,6 +226,49 @@ func neutralFeaturesToV2005(f *Features) *bmecat2005.ProductFeatures {
 		})
 	}
 	return out
+}
+
+// neutralPriceDetailsToV2005 builds the PRODUCT_PRICE_DETAILS wrappers for a
+// product. When the product carries PriceDetails it emits one wrapper per
+// entry, preserving validity dates and grouping; otherwise it falls back to the
+// flattened Prices in a single wrapper, so callers that only set Prices keep
+// the previous behavior. It returns nil when the product has no prices at all.
+func neutralPriceDetailsToV2005(p *Product) []*bmecat2005.ProductPriceDetails {
+	if len(p.PriceDetails) > 0 {
+		var out []*bmecat2005.ProductPriceDetails
+		for _, pd := range p.PriceDetails {
+			if pd == nil {
+				continue
+			}
+			out = append(out, &bmecat2005.ProductPriceDetails{
+				Dates:            validDatesToV2005(pd),
+				DailyPriceString: dailyPriceString(pd.IsDailyPrice),
+				Prices:           neutralPricesToV2005(pd.Prices),
+			})
+		}
+		return out
+	}
+	if prices := neutralPricesToV2005(p.Prices); prices != nil {
+		return []*bmecat2005.ProductPriceDetails{{Prices: prices}}
+	}
+	return nil
+}
+
+// validDatesToV2005 builds the DATETIME entries for a wrapper's validity dates,
+// omitting any that are unset.
+func validDatesToV2005(pd *PriceDetails) []*bmecat2005.DateTime {
+	var dates []*bmecat2005.DateTime
+	if pd.ValidStart != nil {
+		if dt := bmecat2005.NewDateTime(bmecat2005.DateTimeValidStartDate, *pd.ValidStart); dt != nil {
+			dates = append(dates, dt)
+		}
+	}
+	if pd.ValidEnd != nil {
+		if dt := bmecat2005.NewDateTime(bmecat2005.DateTimeValidEndDate, *pd.ValidEnd); dt != nil {
+			dates = append(dates, dt)
+		}
+	}
+	return dates
 }
 
 func neutralPricesToV2005(prices []*Price) []*bmecat2005.ProductPrice {


### PR DESCRIPTION
Closes #36

## Summary

The neutral read model flattened every `ARTICLE_PRICE_DETAILS` (1.2) / `PRODUCT_PRICE_DETAILS` (2005) wrapper into a single `Product.Prices` list, discarding the wrapper boundary and the validity dates each wrapper can carry. A consumer mapping graduated/scale prices could not pick the currently-valid block or detect a price calendar (several dated wrappers).

This implements the issue's preferred option: preserve the wrapper grouping on the neutral model.

## Changes

- **`model.go`** — new neutral `PriceDetails` type (`ValidStart`/`ValidEnd *time.Time`, `IsDailyPrice bool`, `Prices`) and `Product.PriceDetails []*PriceDetails`. `Product.Prices` remains as a documented flattened convenience view.
- **Read path** (`adapter_v12.go`, `adapter_v2005.go`) — builds one neutral `PriceDetails` per source wrapper and flattens `Prices` from it. Validity dates are parsed from the raw `DATETIME` entries and left `nil` when absent — deliberately *not* the version-specific `1970`/`2038` sentinel defaults — so callers can distinguish "no date" from a real bound.
- **Write path** (`writer_v12.go`, `writer_v2005.go`) — emits one wrapper per `Product.PriceDetails` entry (with `DATETIME` + `DAILY_PRICE`), falling back to the previous single-wrapper-from-`Prices` behavior when `PriceDetails` is empty. Preserves round-trip fidelity.
- **Docs** (`doc.go`, `README.md`) — documented the two price views alongside the GTIN note.

## Behavioral note

When a product has both `Prices` and `PriceDetails` set, `PriceDetails` takes precedence on write and `Prices` is ignored (documented in the helper comments).

## Tests

- New `price_details_test.go`: read path (two dated wrappers, graduated prices, daily flag, nil-when-absent end date, flat flattening) and round-trip (dates + grouping + daily flag survive) for both 1.2 and 2005.
- Updated the shared `fullProduct()` fixture so existing `DeepEqual` round-trips still hold.
- `make test` (`-race -tags integration`) and `make build` pass; `go vet` and `gofmt` clean.