### PR TITLE
Emit CLASSIFICATION_SYSTEM on the neutral write path

### DIFF
--- a/model.go
+++ b/model.go
@@ -312,3 +312,38 @@ type ClassificationGroup struct {
 
 func (cg *ClassificationGroup) IsNode() bool { return cg.Type == "node" }
 func (cg *ClassificationGroup) IsLeaf() bool { return cg.Type == "leaf" }
+
+// ClassificationSystem is the version-neutral view of a CLASSIFICATION_SYSTEM
+// element: the classification (e.g. eCl@ss or a supplier UDF system) and its
+// tree of ClassificationGroups. Unlike the streamed product list it is bounded
+// and known up front, so the write path takes it as Writer configuration via
+// WithClassificationSystem rather than over a channel; Writer emits it before
+// the product stream in a T_NEW_CATALOG document.
+//
+// It carries the fields BMEcat 1.2 and 2005 share. Group-level details the
+// neutral ClassificationGroup does not model (the level attribute, synonyms)
+// are not emitted; callers that need them should use the bmecat12 / bmecat2005
+// packages directly.
+type ClassificationSystem struct {
+	Name        string
+	FullName    string
+	Version     string
+	Description string
+	Levels      int
+	LevelNames  []*ClassificationSystemLevelName
+	Groups      []*ClassificationGroup
+}
+
+// IsBlank reports whether the system carries no groups. A blank system is
+// omitted by the writer, mirroring the bmecat12 / bmecat2005 behavior.
+func (cs *ClassificationSystem) IsBlank() bool {
+	return cs == nil || len(cs.Groups) == 0
+}
+
+// ClassificationSystemLevelName is the version-neutral view of a
+// CLASSIFICATION_SYSTEM_LEVEL_NAME element: the human-readable name of one
+// level in the classification hierarchy.
+type ClassificationSystemLevelName struct {
+	Level int
+	Name  string
+}

--- a/writer.go
+++ b/writer.go
@@ -52,11 +52,12 @@ type CatalogWriter interface {
 // directly. The writer also does not emit catalog-group mappings, mirroring the
 // version writers, which do not write them either.
 type Writer struct {
-	w           io.Writer
-	version     Version
-	transaction Transaction
-	prevVersion int
-	indent      string
+	w              io.Writer
+	version        Version
+	transaction    Transaction
+	prevVersion    int
+	indent         string
+	classification *ClassificationSystem
 }
 
 // NewWriter creates a Writer over w. By default it emits BMEcat 1.2 with a
@@ -107,6 +108,17 @@ func WithPreviousVersion(v int) WriterOption {
 func WithIndent(indent string) WriterOption {
 	return func(w *Writer) {
 		w.indent = indent
+	}
+}
+
+// WithClassificationSystem sets the CLASSIFICATION_SYSTEM the writer emits
+// before the product stream. It is emitted only for a NewCatalog transaction,
+// and a nil or blank (no groups) system is omitted, mirroring the bmecat12 /
+// bmecat2005 writers. Because it is supplied as configuration rather than over
+// the product channel, it works the same way for Do and WriteFunc.
+func WithClassificationSystem(cs *ClassificationSystem) WriterOption {
+	return func(w *Writer) {
+		w.classification = cs
 	}
 }
 
@@ -194,18 +206,20 @@ func (c *funcCatalogWriter) Products(ctx context.Context) (<-chan *Product, <-ch
 
 func (w *Writer) writeV12(ctx context.Context, cw CatalogWriter) error {
 	adapter := &v12CatalogWriter{
-		tx:          transactionToV12(w.transaction),
-		prevVersion: w.prevVersion,
-		neutral:     cw,
+		tx:             transactionToV12(w.transaction),
+		prevVersion:    w.prevVersion,
+		neutral:        cw,
+		classification: w.classification,
 	}
 	return bmecat12.NewWriter(w.w, bmecat12.WithIndent(w.indent)).Do(ctx, adapter)
 }
 
 func (w *Writer) writeV2005(ctx context.Context, cw CatalogWriter) error {
 	adapter := &v2005CatalogWriter{
-		tx:          transactionToV2005(w.transaction),
-		prevVersion: w.prevVersion,
-		neutral:     cw,
+		tx:             transactionToV2005(w.transaction),
+		prevVersion:    w.prevVersion,
+		neutral:        cw,
+		classification: w.classification,
 	}
 	return bmecat2005.NewWriter(w.w, bmecat2005.WithIndent(w.indent)).Do(ctx, adapter)
 }

--- a/writer_classification_test.go
+++ b/writer_classification_test.go
@@ -1,0 +1,166 @@
+package bmecat_test
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/olivere/bmecat"
+)
+
+// classificationSystem is a neutral CLASSIFICATION_SYSTEM with system-level
+// metadata, level names, and a node→leaf group tree, so an emit + read-back
+// exercises the whole conversion.
+func classificationSystem() *bmecat.ClassificationSystem {
+	return &bmecat.ClassificationSystem{
+		Name:        "udf_Supplier-1.0",
+		FullName:    "Supplier classification 1.0",
+		Version:     "1.0",
+		Description: "Supplier-defined classification",
+		Levels:      2,
+		LevelNames: []*bmecat.ClassificationSystemLevelName{
+			{Level: 1, Name: "Main group"},
+			{Level: 2, Name: "Sub group"},
+		},
+		Groups: []*bmecat.ClassificationGroup{
+			{Type: "node", ID: "1", Name: "Tools", Description: "All tools"},
+			{Type: "leaf", ID: "2", Name: "Widgets", Description: "Widget tools", ParentID: "1"},
+		},
+	}
+}
+
+// classifCollector captures the header and every classification group the reader
+// surfaces, so a write→read round trip can be asserted.
+type classifCollector struct {
+	groups []*bmecat.ClassificationGroup
+}
+
+func (c *classifCollector) HandleHeader(*bmecat.Header) error { return nil }
+
+func (c *classifCollector) HandleClassificationGroup(g *bmecat.ClassificationGroup) error {
+	c.groups = append(c.groups, g)
+	return nil
+}
+
+// TestWriteClassificationSystemRoundTrip writes a catalog carrying a
+// classification system for each version and reads the groups back, asserting
+// the group tree survives the round trip for both 1.2 and 2005.
+func TestWriteClassificationSystemRoundTrip(t *testing.T) {
+	for _, version := range []bmecat.Version{bmecat.Version12, bmecat.Version2005} {
+		t.Run(version.String(), func(t *testing.T) {
+			cw := &sliceCatalogWriter{
+				header:   fullHeader(),
+				products: []*bmecat.Product{fullProduct()},
+			}
+			var buf bytes.Buffer
+			err := bmecat.NewWriter(
+				&buf,
+				bmecat.WithVersion(version),
+				bmecat.WithClassificationSystem(classificationSystem()),
+			).Do(context.Background(), cw)
+			if err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			// System-level metadata is emitted but not surfaced on read, so
+			// assert it on the wire.
+			out := buf.String()
+			for _, want := range []string{
+				"<CLASSIFICATION_SYSTEM>",
+				"<CLASSIFICATION_SYSTEM_NAME>udf_Supplier-1.0</CLASSIFICATION_SYSTEM_NAME>",
+				"<CLASSIFICATION_SYSTEM_FULLNAME>Supplier classification 1.0</CLASSIFICATION_SYSTEM_FULLNAME>",
+				"<CLASSIFICATION_SYSTEM_LEVELS>2</CLASSIFICATION_SYSTEM_LEVELS>",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("emitted XML missing %q\n%s", want, out)
+				}
+			}
+
+			c := &classifCollector{}
+			r := bmecat.NewReader(bytes.NewReader(buf.Bytes()))
+			if err := r.Do(context.Background(), c); err != nil {
+				t.Fatalf("read: %v", err)
+			}
+
+			want := classificationSystem().Groups
+			if !reflect.DeepEqual(c.groups, want) {
+				t.Errorf("groups round trip mismatch\n got: %+v\nwant: %+v", c.groups, want)
+			}
+		})
+	}
+}
+
+// TestWriteClassificationSystemOmitted confirms that a nil or blank (no groups)
+// classification system, and the default of configuring none at all, emit no
+// CLASSIFICATION_SYSTEM element.
+func TestWriteClassificationSystemOmitted(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []bmecat.WriterOption
+	}{
+		{"none configured", nil},
+		{"nil system", []bmecat.WriterOption{bmecat.WithClassificationSystem(nil)}},
+		{"blank system", []bmecat.WriterOption{bmecat.WithClassificationSystem(&bmecat.ClassificationSystem{Name: "x"})}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cw := &sliceCatalogWriter{header: fullHeader(), products: []*bmecat.Product{fullProduct()}}
+			var buf bytes.Buffer
+			opts := append([]bmecat.WriterOption{bmecat.WithVersion(bmecat.Version12)}, tt.opts...)
+			if err := bmecat.NewWriter(&buf, opts...).Do(context.Background(), cw); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if strings.Contains(buf.String(), "<CLASSIFICATION_SYSTEM>") {
+				t.Errorf("expected no CLASSIFICATION_SYSTEM, got\n%s", buf.String())
+			}
+		})
+	}
+}
+
+// TestWriteClassificationSystemUpdatePrices confirms the classification system
+// is emitted only for a NewCatalog transaction, mirroring the version writers,
+// which gate it behind T_NEW_CATALOG.
+func TestWriteClassificationSystemUpdatePrices(t *testing.T) {
+	cw := &sliceCatalogWriter{header: fullHeader(), products: []*bmecat.Product{fullProduct()}}
+	var buf bytes.Buffer
+	err := bmecat.NewWriter(
+		&buf,
+		bmecat.WithVersion(bmecat.Version12),
+		bmecat.WithTransaction(bmecat.UpdatePrices),
+		bmecat.WithClassificationSystem(classificationSystem()),
+	).Do(context.Background(), cw)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if strings.Contains(buf.String(), "<CLASSIFICATION_SYSTEM>") {
+		t.Errorf("expected no CLASSIFICATION_SYSTEM in T_UPDATE_PRICES, got\n%s", buf.String())
+	}
+}
+
+// TestWriteFuncClassificationSystem confirms the classification system is
+// emitted through the pull-style WriteFunc path too, since it is Writer
+// configuration rather than part of the product stream.
+func TestWriteFuncClassificationSystem(t *testing.T) {
+	var buf bytes.Buffer
+	err := bmecat.NewWriter(
+		&buf,
+		bmecat.WithVersion(bmecat.Version2005),
+		bmecat.WithClassificationSystem(classificationSystem()),
+	).WriteFunc(context.Background(), fullHeader(), func(yield func(*bmecat.Product) error) error {
+		return yield(fullProduct())
+	})
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	c := &classifCollector{}
+	r := bmecat.NewReader(bytes.NewReader(buf.Bytes()))
+	if err := r.Do(context.Background(), c); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !reflect.DeepEqual(c.groups, classificationSystem().Groups) {
+		t.Errorf("groups round trip mismatch\n got: %+v\nwant: %+v", c.groups, classificationSystem().Groups)
+	}
+}

--- a/writer_v12.go
+++ b/writer_v12.go
@@ -23,9 +23,10 @@ func transactionToV12(t Transaction) bmecat12.Transaction {
 // v12CatalogWriter adapts a neutral CatalogWriter to the bmecat12 CatalogWriter
 // contract that bmecat12.Writer.Do drives, converting each product on the fly.
 type v12CatalogWriter struct {
-	tx          bmecat12.Transaction
-	prevVersion int
-	neutral     CatalogWriter
+	tx             bmecat12.Transaction
+	prevVersion    int
+	neutral        CatalogWriter
+	classification *ClassificationSystem
 }
 
 func (c *v12CatalogWriter) Transaction() bmecat12.Transaction { return c.tx }
@@ -42,9 +43,12 @@ func (c *v12CatalogWriter) Language() string {
 	return ""
 }
 
-// ClassificationSystem returns nil: the neutral model has no classification
-// system, so the neutral writer does not emit CLASSIFICATION_SYSTEM.
-func (c *v12CatalogWriter) ClassificationSystem() *bmecat12.ClassificationSystem { return nil }
+// ClassificationSystem converts the neutral classification system configured on
+// the Writer to the bmecat12 type, or returns nil to omit CLASSIFICATION_SYSTEM
+// when none was configured (or it carries no groups).
+func (c *v12CatalogWriter) ClassificationSystem() *bmecat12.ClassificationSystem {
+	return neutralClassificationSystemToV12(c.classification)
+}
 
 // Articles bridges the neutral product stream to the bmecat12 article stream:
 // it reads neutral products from the caller's channel, converts each to a
@@ -107,6 +111,44 @@ func (c *v12CatalogWriter) Articles(ctx context.Context) (<-chan *bmecat12.Artic
 		}
 	}()
 	return out, errc
+}
+
+// neutralClassificationSystemToV12 converts the neutral classification system
+// to the bmecat12 type. It returns nil for a nil or blank system, so the writer
+// omits CLASSIFICATION_SYSTEM exactly as it does for a native bmecat12 source.
+func neutralClassificationSystemToV12(cs *ClassificationSystem) *bmecat12.ClassificationSystem {
+	if cs.IsBlank() {
+		return nil
+	}
+	out := &bmecat12.ClassificationSystem{
+		Name:        cs.Name,
+		FullName:    cs.FullName,
+		Version:     cs.Version,
+		Description: cs.Description,
+		Levels:      cs.Levels,
+	}
+	for _, ln := range cs.LevelNames {
+		if ln == nil {
+			continue
+		}
+		out.LevelNames = append(out.LevelNames, &bmecat12.ClassificationSystemLevelName{
+			Level: ln.Level,
+			Value: ln.Name,
+		})
+	}
+	for _, g := range cs.Groups {
+		if g == nil {
+			continue
+		}
+		out.Groups = append(out.Groups, &bmecat12.ClassificationGroup{
+			Type:        g.Type,
+			ID:          g.ID,
+			Name:        g.Name,
+			Description: g.Description,
+			ParentID:    g.ParentID,
+		})
+	}
+	return out
 }
 
 func neutralHeaderToV12(h *Header) *bmecat12.Header {

--- a/writer_v2005.go
+++ b/writer_v2005.go
@@ -24,9 +24,10 @@ func transactionToV2005(t Transaction) bmecat2005.Transaction {
 // CatalogWriter contract that bmecat2005.Writer.Do drives, converting each
 // product on the fly.
 type v2005CatalogWriter struct {
-	tx          bmecat2005.Transaction
-	prevVersion int
-	neutral     CatalogWriter
+	tx             bmecat2005.Transaction
+	prevVersion    int
+	neutral        CatalogWriter
+	classification *ClassificationSystem
 }
 
 func (c *v2005CatalogWriter) Transaction() bmecat2005.Transaction { return c.tx }
@@ -43,9 +44,12 @@ func (c *v2005CatalogWriter) Language() string {
 	return ""
 }
 
-// ClassificationSystem returns nil: the neutral model has no classification
-// system, so the neutral writer does not emit CLASSIFICATION_SYSTEM.
-func (c *v2005CatalogWriter) ClassificationSystem() *bmecat2005.ClassificationSystem { return nil }
+// ClassificationSystem converts the neutral classification system configured on
+// the Writer to the bmecat2005 type, or returns nil to omit CLASSIFICATION_SYSTEM
+// when none was configured (or it carries no groups).
+func (c *v2005CatalogWriter) ClassificationSystem() *bmecat2005.ClassificationSystem {
+	return neutralClassificationSystemToV2005(c.classification)
+}
 
 // Products bridges the neutral product stream to the bmecat2005 product stream:
 // it reads neutral products from the caller's channel, converts each to a
@@ -108,6 +112,45 @@ func (c *v2005CatalogWriter) Products(ctx context.Context) (<-chan *bmecat2005.P
 		}
 	}()
 	return out, errc
+}
+
+// neutralClassificationSystemToV2005 converts the neutral classification system
+// to the bmecat2005 type. It returns nil for a nil or blank system, so the
+// writer omits CLASSIFICATION_SYSTEM exactly as it does for a native bmecat2005
+// source.
+func neutralClassificationSystemToV2005(cs *ClassificationSystem) *bmecat2005.ClassificationSystem {
+	if cs.IsBlank() {
+		return nil
+	}
+	out := &bmecat2005.ClassificationSystem{
+		Name:        cs.Name,
+		FullName:    cs.FullName,
+		Version:     cs.Version,
+		Description: cs.Description,
+		Levels:      cs.Levels,
+	}
+	for _, ln := range cs.LevelNames {
+		if ln == nil {
+			continue
+		}
+		out.LevelNames = append(out.LevelNames, &bmecat2005.ClassificationSystemLevelName{
+			Level: ln.Level,
+			Value: ln.Name,
+		})
+	}
+	for _, g := range cs.Groups {
+		if g == nil {
+			continue
+		}
+		out.Groups = append(out.Groups, &bmecat2005.ClassificationGroup{
+			Type:        g.Type,
+			ID:          g.ID,
+			Name:        g.Name,
+			Description: g.Description,
+			ParentID:    g.ParentID,
+		})
+	}
+	return out
 }
 
 func neutralHeaderToV2005(h *Header) *bmecat2005.Header {


### PR DESCRIPTION
## Summary

Implements the **classification half** of #34: the neutral write path can now emit `CLASSIFICATION_SYSTEM`. The catalog-group system + maps (the harder, separate-mapping-after-products half) are split into a follow-up issue.

- **Neutral model:** new `ClassificationSystem` (Name, FullName, Version, Description, Levels, LevelNames, Groups) reusing the existing neutral `ClassificationGroup`, plus `ClassificationSystemLevelName`. `IsBlank()` mirrors the version types.
- **Write path:** new `WithClassificationSystem(*ClassificationSystem)` Writer option. Both version adapters convert neutral→version and emit `CLASSIFICATION_SYSTEM` before the product stream, gated to `T_NEW_CATALOG`, omitting blank systems — matching the bmecat12/bmecat2005 writers.

## Why a Writer option, not a `CatalogWriter` method

The classification system is bounded and known up front (unlike the streamed products), so it's supplied as Writer configuration. This is **non-breaking** for the recently-added `CatalogWriter` interface and works uniformly for both `Do` and the ergonomic `WriteFunc`:

```go
bmecat.NewWriter(w, bmecat.WithClassificationSystem(cs)).WriteFunc(ctx, header, produce)
```

## Tests

`writer_classification_test.go`: group-tree round-trip for 1.2 + 2005, system metadata asserted on the wire, omission of nil/blank/unconfigured systems, `T_UPDATE_PRICES` gating, and the `WriteFunc` path. `go test`, `go vet`, `gofumpt`, `staticcheck` all clean.

## Out of scope (tracked in follow-up)

- `CATALOG_GROUP_SYSTEM` + `ARTICLE_TO_CATALOGGROUP_MAP` / `PRODUCT_TO_CATALOGGROUP_MAP` emission.
- Neutral `ClassificationGroup` still omits the `level` attribute and synonyms.

Closes #34