### PR TITLE
Escape character-data fields tagged with xml:",innerxml" (#43)

### DIFF
--- a/bmecat12/classification_group.go
+++ b/bmecat12/classification_group.go
@@ -28,7 +28,7 @@ type ClassificationSystemLevelName struct {
 	XMLName xml.Name `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAME"`
 
 	Level int    `xml:"level,attr"`
-	Value string `xml:",innerxml"`
+	Value string `xml:",chardata"`
 }
 
 type ClassificationGroup struct {

--- a/bmecat12/header.go
+++ b/bmecat12/header.go
@@ -48,7 +48,7 @@ const (
 
 type PriceFlag struct {
 	Type  string `xml:"type,attr"`
-	Value string `xml:",innerxml"`
+	Value string `xml:",chardata"`
 }
 
 var (

--- a/bmecat12/model_test.go
+++ b/bmecat12/model_test.go
@@ -1,6 +1,8 @@
 package bmecat12
 
 import (
+	"encoding/xml"
+	"strings"
 	"testing"
 	"time"
 )
@@ -257,5 +259,47 @@ func TestUDXGetNotFound(t *testing.T) {
 	}
 	if _, ok := fields.GetInnerXML("MISSING"); ok {
 		t.Error("GetInnerXML(MISSING) ok = true, want false")
+	}
+}
+
+func TestClassificationSystemLevelNameSpecialCharsRoundTrip(t *testing.T) {
+	const value = "Tools & Co <Main> \"group\""
+	in := ClassificationSystemLevelName{Level: 1, Value: value}
+
+	buf, err := xml.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if strings.Contains(string(buf), "Tools & Co") {
+		t.Errorf("Marshal() produced unescaped output: %s", buf)
+	}
+
+	var out ClassificationSystemLevelName
+	if err := xml.Unmarshal(buf, &out); err != nil {
+		t.Fatalf("Unmarshal() error = %v, xml = %s", err, buf)
+	}
+	if out.Value != value {
+		t.Errorf("Value = %q, want %q", out.Value, value)
+	}
+}
+
+func TestPriceFlagSpecialCharsRoundTrip(t *testing.T) {
+	const value = "true & valid <x>"
+	in := PriceFlag{Type: PriceFlagInclFreight, Value: value}
+
+	buf, err := xml.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if strings.Contains(string(buf), "true & valid") {
+		t.Errorf("Marshal() produced unescaped output: %s", buf)
+	}
+
+	var out PriceFlag
+	if err := xml.Unmarshal(buf, &out); err != nil {
+		t.Fatalf("Unmarshal() error = %v, xml = %s", err, buf)
+	}
+	if out.Value != value {
+		t.Errorf("Value = %q, want %q", out.Value, value)
 	}
 }

--- a/bmecat2005/classification_group.go
+++ b/bmecat2005/classification_group.go
@@ -28,7 +28,7 @@ type ClassificationSystemLevelName struct {
 	XMLName xml.Name `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAME"`
 
 	Level int    `xml:"level,attr"`
-	Value string `xml:",innerxml"`
+	Value string `xml:",chardata"`
 }
 
 type ClassificationGroup struct {

--- a/bmecat2005/header.go
+++ b/bmecat2005/header.go
@@ -48,7 +48,7 @@ const (
 
 type PriceFlag struct {
 	Type  string `xml:"type,attr"`
-	Value string `xml:",innerxml"`
+	Value string `xml:",chardata"`
 }
 
 var (

--- a/bmecat2005/model_test.go
+++ b/bmecat2005/model_test.go
@@ -1,6 +1,8 @@
 package bmecat2005
 
 import (
+	"encoding/xml"
+	"strings"
 	"testing"
 	"time"
 )
@@ -264,5 +266,47 @@ func TestUDXGetNotFound(t *testing.T) {
 	}
 	if _, ok := fields.GetInnerXML("MISSING"); ok {
 		t.Error("GetInnerXML(MISSING) ok = true, want false")
+	}
+}
+
+func TestClassificationSystemLevelNameSpecialCharsRoundTrip(t *testing.T) {
+	const value = "Tools & Co <Main> \"group\""
+	in := ClassificationSystemLevelName{Level: 1, Value: value}
+
+	buf, err := xml.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if strings.Contains(string(buf), "Tools & Co") {
+		t.Errorf("Marshal() produced unescaped output: %s", buf)
+	}
+
+	var out ClassificationSystemLevelName
+	if err := xml.Unmarshal(buf, &out); err != nil {
+		t.Fatalf("Unmarshal() error = %v, xml = %s", err, buf)
+	}
+	if out.Value != value {
+		t.Errorf("Value = %q, want %q", out.Value, value)
+	}
+}
+
+func TestPriceFlagSpecialCharsRoundTrip(t *testing.T) {
+	const value = "true & valid <x>"
+	in := PriceFlag{Type: PriceFlagInclFreight, Value: value}
+
+	buf, err := xml.Marshal(&in)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if strings.Contains(string(buf), "true & valid") {
+		t.Errorf("Marshal() produced unescaped output: %s", buf)
+	}
+
+	var out PriceFlag
+	if err := xml.Unmarshal(buf, &out); err != nil {
+		t.Fatalf("Unmarshal() error = %v, xml = %s", err, buf)
+	}
+	if out.Value != value {
+		t.Errorf("Value = %q, want %q", out.Value, value)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #43. `ClassificationSystemLevelName.Value` was tagged `xml:",innerxml"` in both `bmecat12` and `bmecat2005`, so `encoding/xml` wrote the value verbatim without escaping. A level name containing `&`, `<`, or `>` produced malformed XML that fails to parse on read-back. This became newly reachable through the neutral `WithClassificationSystem` API added in #41.

Switched the tag to `xml:",chardata"`, which escapes on write and unescapes on read.

## Other instances audited

Grepping for `,innerxml` across the version packages turned up four usages:

- `ClassificationSystemLevelName.Value` (bmecat12 + bmecat2005) — **fixed** (the issue).
- `PriceFlag.Value` (bmecat12 + bmecat2005) — **fixed**. Same class of bug: a character-data field tagged `,innerxml`. In practice it only ever holds `"true"`, so the risk was theoretical, but `,chardata` is strictly more correct.
- `UserDefinedExtensionField.InnerXML` and the `Raw` injection path in `udx.go` — **left unchanged**. These are intentionally raw XML (`AddRaw` documents the caller as responsible for valid XML, and `GetInnerXML` exposes the captured inner XML).

## Tests

Added round-trip tests with special characters (`&`, `<`, `>`, `"`) for both fixed fields in each package, asserting the marshaled output is escaped and the value survives a marshal/unmarshal round trip. Full suite passes; `go vet` clean.