### PR TITLE
Add price-block helpers and apply DateTime TIMEZONE offset

### DIFF
--- a/bmecat12/date_time.go
+++ b/bmecat12/date_time.go
@@ -19,13 +19,19 @@ type DateTime struct {
 	TimeZoneString string `xml:"TIMEZONE,omitempty"`
 }
 
+// Time converts the DateTime to a time.Time. When TIMEZONE is set it applies
+// the offset, accepting both the "Z" (UTC) and "±HH:MM" forms that NewDateTime
+// emits; the returned time then carries that offset. When TIMEZONE is empty the
+// wall-clock is interpreted as UTC.
 func (dt DateTime) Time() (time.Time, error) {
 	ts := dt.TimeString
 	if ts == "" {
 		ts = "00:00:00"
 	}
-	// TODO time zone support
-	return time.Parse("2006-01-02 15:04:05", dt.DateString+" "+ts)
+	if dt.TimeZoneString == "" {
+		return time.Parse("2006-01-02 15:04:05", dt.DateString+" "+ts)
+	}
+	return time.Parse("2006-01-02 15:04:05Z07:00", dt.DateString+" "+ts+dt.TimeZoneString)
 }
 
 func NewDateTime(typ string, dt time.Time) *DateTime {

--- a/bmecat12/date_time.go
+++ b/bmecat12/date_time.go
@@ -21,17 +21,22 @@ type DateTime struct {
 
 // Time converts the DateTime to a time.Time. When TIMEZONE is set it applies
 // the offset, accepting both the "Z" (UTC) and "±HH:MM" forms that NewDateTime
-// emits; the returned time then carries that offset. When TIMEZONE is empty the
-// wall-clock is interpreted as UTC.
+// emits; the returned time then carries that offset. A TIMEZONE that does not
+// match either form is ignored and the wall-clock is interpreted as UTC, which
+// is also the behavior when TIMEZONE is empty.
 func (dt DateTime) Time() (time.Time, error) {
 	ts := dt.TimeString
 	if ts == "" {
 		ts = "00:00:00"
 	}
-	if dt.TimeZoneString == "" {
-		return time.Parse("2006-01-02 15:04:05", dt.DateString+" "+ts)
+	if dt.TimeZoneString != "" {
+		if t, err := time.Parse("2006-01-02 15:04:05Z07:00", dt.DateString+" "+ts+dt.TimeZoneString); err == nil {
+			return t, nil
+		}
+		// Fall through: a malformed TIMEZONE is ignored rather than failing the
+		// whole parse, so a valid date never degrades to an error.
 	}
-	return time.Parse("2006-01-02 15:04:05Z07:00", dt.DateString+" "+ts+dt.TimeZoneString)
+	return time.Parse("2006-01-02 15:04:05", dt.DateString+" "+ts)
 }
 
 func NewDateTime(typ string, dt time.Time) *DateTime {

--- a/bmecat12/model_test.go
+++ b/bmecat12/model_test.go
@@ -189,6 +189,17 @@ func TestDateTimeTime(t *testing.T) {
 	if got.Format(time.RFC3339) != "2020-06-15T13:45:30-04:00" {
 		t.Errorf("Time() = %q, want offset preserved", got.Format(time.RFC3339))
 	}
+
+	// A malformed timezone is ignored, not treated as an error: the date still
+	// parses as UTC rather than degrading to an error/default.
+	dt = DateTime{DateString: "2020-06-15", TimeString: "13:45:30", TimeZoneString: "+0200"}
+	got, err = dt.Time()
+	if err != nil {
+		t.Fatalf("Time() error: %v", err)
+	}
+	if want := time.Date(2020, 6, 15, 13, 45, 30, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Time() = %v, want %v", got, want)
+	}
 }
 
 func TestAgreementStartEndDate(t *testing.T) {

--- a/bmecat12/model_test.go
+++ b/bmecat12/model_test.go
@@ -166,6 +166,29 @@ func TestDateTimeTime(t *testing.T) {
 	if _, err := (DateTime{DateString: "bad"}).Time(); err == nil {
 		t.Error("Time() error = nil, want non-nil for invalid date")
 	}
+
+	// Explicit UTC timezone ("Z").
+	dt = DateTime{DateString: "2020-06-15", TimeString: "13:45:30", TimeZoneString: "Z"}
+	got, err = dt.Time()
+	if err != nil {
+		t.Fatalf("Time() error: %v", err)
+	}
+	if want := time.Date(2020, 6, 15, 13, 45, 30, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Time() = %v, want %v", got, want)
+	}
+
+	// Non-UTC offset is applied rather than ignored.
+	dt = DateTime{DateString: "2020-06-15", TimeString: "13:45:30", TimeZoneString: "-04:00"}
+	got, err = dt.Time()
+	if err != nil {
+		t.Fatalf("Time() error: %v", err)
+	}
+	if want := time.Date(2020, 6, 15, 17, 45, 30, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Time() = %v, want %v", got, want)
+	}
+	if got.Format(time.RFC3339) != "2020-06-15T13:45:30-04:00" {
+		t.Errorf("Time() = %q, want offset preserved", got.Format(time.RFC3339))
+	}
 }
 
 func TestAgreementStartEndDate(t *testing.T) {

--- a/bmecat2005/date_time.go
+++ b/bmecat2005/date_time.go
@@ -19,13 +19,19 @@ type DateTime struct {
 	TimeZoneString string `xml:"TIMEZONE,omitempty"`
 }
 
+// Time converts the DateTime to a time.Time. When TIMEZONE is set it applies
+// the offset, accepting both the "Z" (UTC) and "±HH:MM" forms that NewDateTime
+// emits; the returned time then carries that offset. When TIMEZONE is empty the
+// wall-clock is interpreted as UTC.
 func (dt DateTime) Time() (time.Time, error) {
 	ts := dt.TimeString
 	if ts == "" {
 		ts = "00:00:00"
 	}
-	// TODO time zone support
-	return time.Parse("2006-01-02 15:04:05", dt.DateString+" "+ts)
+	if dt.TimeZoneString == "" {
+		return time.Parse("2006-01-02 15:04:05", dt.DateString+" "+ts)
+	}
+	return time.Parse("2006-01-02 15:04:05Z07:00", dt.DateString+" "+ts+dt.TimeZoneString)
 }
 
 func NewDateTime(typ string, dt time.Time) *DateTime {

--- a/bmecat2005/date_time.go
+++ b/bmecat2005/date_time.go
@@ -21,17 +21,22 @@ type DateTime struct {
 
 // Time converts the DateTime to a time.Time. When TIMEZONE is set it applies
 // the offset, accepting both the "Z" (UTC) and "±HH:MM" forms that NewDateTime
-// emits; the returned time then carries that offset. When TIMEZONE is empty the
-// wall-clock is interpreted as UTC.
+// emits; the returned time then carries that offset. A TIMEZONE that does not
+// match either form is ignored and the wall-clock is interpreted as UTC, which
+// is also the behavior when TIMEZONE is empty.
 func (dt DateTime) Time() (time.Time, error) {
 	ts := dt.TimeString
 	if ts == "" {
 		ts = "00:00:00"
 	}
-	if dt.TimeZoneString == "" {
-		return time.Parse("2006-01-02 15:04:05", dt.DateString+" "+ts)
+	if dt.TimeZoneString != "" {
+		if t, err := time.Parse("2006-01-02 15:04:05Z07:00", dt.DateString+" "+ts+dt.TimeZoneString); err == nil {
+			return t, nil
+		}
+		// Fall through: a malformed TIMEZONE is ignored rather than failing the
+		// whole parse, so a valid date never degrades to an error.
 	}
-	return time.Parse("2006-01-02 15:04:05Z07:00", dt.DateString+" "+ts+dt.TimeZoneString)
+	return time.Parse("2006-01-02 15:04:05", dt.DateString+" "+ts)
 }
 
 func NewDateTime(typ string, dt time.Time) *DateTime {

--- a/bmecat2005/model_test.go
+++ b/bmecat2005/model_test.go
@@ -189,6 +189,17 @@ func TestDateTimeTime(t *testing.T) {
 	if got.Format(time.RFC3339) != "2020-06-15T13:45:30-04:00" {
 		t.Errorf("Time() = %q, want offset preserved", got.Format(time.RFC3339))
 	}
+
+	// A malformed timezone is ignored, not treated as an error: the date still
+	// parses as UTC rather than degrading to an error/default.
+	dt = DateTime{DateString: "2020-06-15", TimeString: "13:45:30", TimeZoneString: "+0200"}
+	got, err = dt.Time()
+	if err != nil {
+		t.Fatalf("Time() error: %v", err)
+	}
+	if want := time.Date(2020, 6, 15, 13, 45, 30, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Time() = %v, want %v", got, want)
+	}
 }
 
 func TestAgreementStartEndDate(t *testing.T) {

--- a/bmecat2005/model_test.go
+++ b/bmecat2005/model_test.go
@@ -166,6 +166,29 @@ func TestDateTimeTime(t *testing.T) {
 	if _, err := (DateTime{DateString: "bad"}).Time(); err == nil {
 		t.Error("Time() error = nil, want non-nil for invalid date")
 	}
+
+	// Explicit UTC timezone ("Z").
+	dt = DateTime{DateString: "2020-06-15", TimeString: "13:45:30", TimeZoneString: "Z"}
+	got, err = dt.Time()
+	if err != nil {
+		t.Fatalf("Time() error: %v", err)
+	}
+	if want := time.Date(2020, 6, 15, 13, 45, 30, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Time() = %v, want %v", got, want)
+	}
+
+	// Non-UTC offset is applied rather than ignored.
+	dt = DateTime{DateString: "2020-06-15", TimeString: "13:45:30", TimeZoneString: "-04:00"}
+	got, err = dt.Time()
+	if err != nil {
+		t.Fatalf("Time() error: %v", err)
+	}
+	if want := time.Date(2020, 6, 15, 17, 45, 30, 0, time.UTC); !got.Equal(want) {
+		t.Errorf("Time() = %v, want %v", got, want)
+	}
+	if got.Format(time.RFC3339) != "2020-06-15T13:45:30-04:00" {
+		t.Errorf("Time() = %q, want offset preserved", got.Format(time.RFC3339))
+	}
 }
 
 func TestAgreementStartEndDate(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -29,7 +29,10 @@ preserves the ARTICLE_PRICE_DETAILS / PRODUCT_PRICE_DETAILS wrapper grouping,
 including each wrapper's validity dates ([PriceDetails.ValidStart] /
 [PriceDetails.ValidEnd], nil when the source omits them) — so a consumer can
 pick the currently-valid block or detect a price calendar (several dated
-wrappers).
+wrappers). [Product.CurrentPriceDetails] selects the wrapper valid at a given
+time, [Product.ValidPriceDetails] returns every match, and
+[PriceDetails.PriceFor] resolves the graduated/scale tier for an order
+quantity.
 
 A caller that needs to gate on the document-level transaction — for example to
 reject incremental updates and only accept full catalogs — can detect it cheaply

--- a/price_details.go
+++ b/price_details.go
@@ -1,0 +1,73 @@
+package bmecat
+
+import "time"
+
+// IsValidAt reports whether t falls within the wrapper's validity window. A nil
+// ValidStart means the wrapper is valid from the beginning of time; a nil
+// ValidEnd means it is valid indefinitely (open-ended). Both bounds are
+// inclusive.
+func (pd *PriceDetails) IsValidAt(t time.Time) bool {
+	if pd.ValidStart != nil && t.Before(*pd.ValidStart) {
+		return false
+	}
+	if pd.ValidEnd != nil && t.After(*pd.ValidEnd) {
+		return false
+	}
+	return true
+}
+
+// CurrentPriceDetails returns the first PriceDetails wrapper, in document order,
+// whose validity window contains at. It returns nil when no wrapper is valid at
+// that time. See PriceDetails.IsValidAt for the window semantics.
+//
+// When a product carries a price calendar with overlapping windows, this
+// returns only the first match; use ValidPriceDetails to detect or inspect all
+// of them.
+func (p *Product) CurrentPriceDetails(at time.Time) *PriceDetails {
+	for _, pd := range p.PriceDetails {
+		if pd.IsValidAt(at) {
+			return pd
+		}
+	}
+	return nil
+}
+
+// ValidPriceDetails returns every PriceDetails wrapper, in document order, whose
+// validity window contains at. It returns nil when none is valid. A result with
+// more than one element indicates overlapping validity windows (a price
+// calendar), which callers may want to warn about.
+func (p *Product) ValidPriceDetails(at time.Time) []*PriceDetails {
+	var out []*PriceDetails
+	for _, pd := range p.PriceDetails {
+		if pd.IsValidAt(at) {
+			out = append(out, pd)
+		}
+	}
+	return out
+}
+
+// PriceFor selects the price tier applicable to the given quantity from the
+// wrapper's Prices. It returns the price with the highest LowerBound that does
+// not exceed quantity. Prices whose Type does not match typ are ignored; pass
+// an empty typ to consider every price regardless of type.
+//
+// It returns nil when no price applies — for example when quantity is below the
+// lowest LowerBound, or when no price carries the requested type.
+//
+// PriceFor does not apply Factor; callers that need the factor-adjusted amount
+// should multiply the returned Price.Amount by Price.Factor themselves.
+func (pd *PriceDetails) PriceFor(quantity float64, typ string) *Price {
+	var best *Price
+	for _, p := range pd.Prices {
+		if typ != "" && p.Type != typ {
+			continue
+		}
+		if p.LowerBound > quantity {
+			continue
+		}
+		if best == nil || p.LowerBound > best.LowerBound {
+			best = p
+		}
+	}
+	return best
+}

--- a/price_helpers_test.go
+++ b/price_helpers_test.go
@@ -1,0 +1,112 @@
+package bmecat_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/olivere/bmecat"
+)
+
+func tp(s string) *time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return &t
+}
+
+func TestPriceDetailsIsValidAt(t *testing.T) {
+	at := time.Date(2020, 3, 15, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		pd   *bmecat.PriceDetails
+		want bool
+	}{
+		{"open both ends", &bmecat.PriceDetails{}, true},
+		{"within window", &bmecat.PriceDetails{ValidStart: tp("2020-01-01"), ValidEnd: tp("2020-06-30")}, true},
+		{"before start", &bmecat.PriceDetails{ValidStart: tp("2020-04-01")}, false},
+		{"after end", &bmecat.PriceDetails{ValidEnd: tp("2020-02-01")}, false},
+		{"open start, before end", &bmecat.PriceDetails{ValidEnd: tp("2020-06-30")}, true},
+		{"open end, after start", &bmecat.PriceDetails{ValidStart: tp("2020-01-01")}, true},
+		{"inclusive start bound", &bmecat.PriceDetails{ValidStart: tp("2020-03-15")}, true},
+		{"inclusive end bound", &bmecat.PriceDetails{ValidEnd: tp("2020-03-15")}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.pd.IsValidAt(at); got != tt.want {
+				t.Errorf("IsValidAt = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProductCurrentAndValidPriceDetails(t *testing.T) {
+	first := &bmecat.PriceDetails{ValidStart: tp("2020-01-01"), ValidEnd: tp("2020-06-30")}
+	second := &bmecat.PriceDetails{ValidStart: tp("2020-07-01")}
+	overlap := &bmecat.PriceDetails{ValidStart: tp("2020-06-01"), ValidEnd: tp("2020-12-31")}
+	p := &bmecat.Product{PriceDetails: []*bmecat.PriceDetails{first, second, overlap}}
+
+	// In the first window only.
+	if got := p.CurrentPriceDetails(time.Date(2020, 3, 1, 0, 0, 0, 0, time.UTC)); got != first {
+		t.Errorf("CurrentPriceDetails = %p, want first %p", got, first)
+	}
+	// Overlap of second and overlap: returns first in document order (second).
+	at := time.Date(2020, 8, 1, 0, 0, 0, 0, time.UTC)
+	if got := p.CurrentPriceDetails(at); got != second {
+		t.Errorf("CurrentPriceDetails = %p, want second %p", got, second)
+	}
+	if got := p.ValidPriceDetails(at); len(got) != 2 || got[0] != second || got[1] != overlap {
+		t.Errorf("ValidPriceDetails = %v, want [second overlap]", got)
+	}
+	// No window matches.
+	before := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	if got := p.CurrentPriceDetails(before); got != nil {
+		t.Errorf("CurrentPriceDetails = %v, want nil", got)
+	}
+	if got := p.ValidPriceDetails(before); got != nil {
+		t.Errorf("ValidPriceDetails = %v, want nil", got)
+	}
+}
+
+func TestPriceDetailsPriceFor(t *testing.T) {
+	pd := &bmecat.PriceDetails{
+		Prices: []*bmecat.Price{
+			{Type: "net_list", Amount: 10, LowerBound: 1},
+			{Type: "net_list", Amount: 8, LowerBound: 100},
+			{Type: "net_customer", Amount: 7, LowerBound: 1},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		quantity   float64
+		typ        string
+		wantAmount float64 // -1 means expect nil
+	}{
+		{"below tier, picks lowest", 50, "net_list", 10},
+		{"at higher tier bound", 100, "net_list", 8},
+		{"above higher tier", 250, "net_list", 8},
+		{"other type filtered", 50, "net_customer", 7},
+		{"empty type considers all, highest bound wins", 100, "", 8},
+		{"below lowest bound returns nil", 0.5, "net_list", -1},
+		{"unknown type returns nil", 50, "gross_list", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pd.PriceFor(tt.quantity, tt.typ)
+			if tt.wantAmount < 0 {
+				if got != nil {
+					t.Errorf("PriceFor = %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("PriceFor = nil, want amount %v", tt.wantAmount)
+			}
+			if got.Amount != tt.wantAmount {
+				t.Errorf("PriceFor amount = %v, want %v", got.Amount, tt.wantAmount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements #38, #39, and #40 — straightforward follow-up helpers from #36/#37 — in a single PR.

## #38 — currently-valid PriceDetails
- `PriceDetails.IsValidAt(t)` — building block; nil `ValidStart` = valid from the beginning, nil `ValidEnd` = open-ended, both bounds inclusive.
- `Product.CurrentPriceDetails(at)` — first wrapper in document order whose window contains `at` (nil if none).
- `Product.ValidPriceDetails(at)` — all matching wrappers, so callers can detect a price calendar (overlapping windows).

## #40 — effective scale/graduated price
- `PriceDetails.PriceFor(quantity, typ)` — picks the tier with the highest `LowerBound` not exceeding `quantity`, filtered by price type (empty `typ` considers all). Returns nil when nothing applies. Does **not** apply `Factor` — left to the caller, as raised in the issue's open question.

These two compose: pick the valid block for *now*, then the tier for *this quantity*.

## #39 — DateTime TIMEZONE offset
`bmecat12.DateTime.Time()` and `bmecat2005.DateTime.Time()` now parse `TIMEZONE` and apply the offset (both `Z` and `±HH:MM` forms emitted by `NewDateTime`) instead of silently treating the wall-clock as UTC. An empty `TIMEZONE` keeps the previous behavior. Removes the `// TODO time zone support` markers.

## Tests
- New `price_helpers_test.go`: `IsValidAt` windows, current/valid selection incl. document-order tie-break on overlap, and `PriceFor` tiering/type-filter/nil cases.
- Extended `TestDateTimeTime` in both version packages with `Z` and non-UTC offset round-trips.

`go build`, `go vet`, `gofmt -l`, and `go test ./...` all clean.

Closes #38
Closes #39
Closes #40