### PR TITLE
Expose lang-tagged BMEcat 2005 text fields as LocalizedStrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ func (handler) HandleHeader(h *bmecat.Header) error {
 }
 
 func (handler) HandleProduct(p *bmecat.Product) error {
-	fmt.Printf("Product %s: %s (GTIN %s)\n", p.ID, p.DescriptionShort, p.GTIN)
+	fmt.Printf("Product %s: %s (GTIN %s)\n", p.ID, p.DescriptionShort.Value(), p.GTIN)
 	return nil
 }
 
@@ -73,6 +73,36 @@ func main() {
 
 The neutral model exposes the fields 1.2 and 2005 share; in particular
 `Product.GTIN` unifies the 1.2 `EAN` and 2005 `INTERNATIONAL_PID` elements.
+
+BMEcat 2005 lets many text elements repeat once per language (the spec's
+`dtMLSTRING` type). Those fields are exposed as `LocalizedStrings`, preserving
+every variant in document order, so a consumer can pick the one matching a
+configured language with `p.DescriptionShort.Get("eng")` (which falls back to the
+first variant when the language is absent) or take the first with
+`p.DescriptionShort.Value()`. For elements that legitimately repeat (`KEYWORD`,
+`SEGMENT`, feature values), `p.Keywords.All("eng")` returns every value for a
+language. Build the common single-language value with `bmecat.Localized("Widget")`
+(it is variadic: `bmecat.Localized("a", "b")` builds a list). Every element the
+2005 schema types as `dtMLSTRING` is covered — on the neutral model the catalog
+name; product short/long description, manufacturer type description, keywords,
+remarks and segments; feature group name, feature names and values; MIME source
+and description — and, in the `bmecat2005` package, additionally address parts
+(name, street, city, …), MIME alt, feature descriptions/value-details/variant
+values, catalog-group keywords, classification-group synonyms and classification
+system level names. Identifiers and codes the schema types as plain strings (e.g.
+`MANUFACTURER_NAME`, `SUPPLIER_NAME`, `FUNIT`, the classification system name,
+`EMAIL`/`URL`) stay scalar.
+
+BMEcat 1.2 has no per-element `lang` attribute — it declares one catalog language
+in the header — so the `bmecat12` structs keep plain `string`/`[]string` fields.
+Reading a 1.2 document fills each `LocalizedStrings` with a single language-less
+variant; writing the neutral model to 1.2 emits the variant matching the
+catalog's language (falling back to the first), which is lossy for genuinely
+multi-language data. The `lang` attribute is written (in 2005) only for variants
+that set a language, so single-language catalogs round-trip unchanged.
+
+This replaced the former scalar fields: update reads such as `p.DescriptionShort`
+to `p.DescriptionShort.Value()` (or `.Get(lang)` / `.All(lang)`).
 Prices come both flattened (`Product.Prices`) and grouped by their
 `ARTICLE_PRICE_DETAILS` / `PRODUCT_PRICE_DETAILS` wrapper with validity dates
 (`Product.PriceDetails`), so you can pick the currently-valid block or spot a
@@ -124,7 +154,7 @@ func (handler) HandleHeader(h *bmecat12.Header) error {
 }
 
 func (handler) HandleArticle(a *bmecat12.Article) error {
-	fmt.Printf("Article %s: %s\n", a.SupplierAID, a.Details.DescriptionShort)
+	fmt.Printf("Article %s: %s\n", a.SupplierAID, a.Details.DescriptionShort.Value())
 	return nil
 }
 

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -102,7 +102,7 @@ func TestReadGroupsDispatch(t *testing.T) {
 			if want, have := "10", cg.ID; want != have {
 				t.Errorf("want catalog group ID %q, have %q", want, have)
 			}
-			if want, have := "Hardware", cg.Name; want != have {
+			if want, have := "Hardware", cg.Name.Value(); want != have {
 				t.Errorf("want catalog group name %q, have %q", want, have)
 			}
 			if !cg.IsNode() {
@@ -332,7 +332,7 @@ func TestNeutralProductOrderAndDetailFields(t *testing.T) {
 			}
 
 			// Article/product details.
-			if want, have := "Type-X", p.ManufacturerTypeDescr; want != have {
+			if want, have := "Type-X", p.ManufacturerTypeDescr.Value(); want != have {
 				t.Errorf("ManufacturerTypeDescr = %q, want %q", have, want)
 			}
 			if want, have := "EGB", p.ERPGroupBuyer; want != have {
@@ -346,10 +346,10 @@ func TestNeutralProductOrderAndDetailFields(t *testing.T) {
 			} else if want, have := 5, *p.DeliveryTime; want != have {
 				t.Errorf("DeliveryTime = %d, want %d", have, want)
 			}
-			if want, have := "handle with care", p.Remarks; want != have {
+			if want, have := "handle with care", p.Remarks.Value(); want != have {
 				t.Errorf("Remarks = %q, want %q", have, want)
 			}
-			if want, have := []string{"seg-a"}, p.Segments; len(have) != 1 || have[0] != want[0] {
+			if want, have := []string{"seg-a"}, p.Segments.All(""); len(have) != 1 || have[0] != want[0] {
 				t.Errorf("Segments = %v, want %v", have, want)
 			}
 			if want, have := 1, len(p.BuyerIDs); want != have {

--- a/adapter_v12.go
+++ b/adapter_v12.go
@@ -76,8 +76,8 @@ func (a *v12Adapter) HandleCatalogGroup(cg *bmecat12.CatalogGroup) error {
 	return a.catalogGroup.HandleCatalogGroup(&CatalogGroup{
 		Type:        cg.Type,
 		ID:          cg.ID,
-		Name:        cg.Name,
-		Description: cg.Description,
+		Name:        localizedFromV12(cg.Name),
+		Description: localizedFromV12(cg.Description),
 		ParentID:    cg.ParentID,
 		Order:       cg.Order,
 	})
@@ -90,8 +90,8 @@ func (a *v12Adapter) HandleClassificationGroup(cg *bmecat12.ClassificationGroup)
 	return a.classifGroup.HandleClassificationGroup(&ClassificationGroup{
 		Type:        cg.Type,
 		ID:          cg.ID,
-		Name:        cg.Name,
-		Description: cg.Description,
+		Name:        localizedFromV12(cg.Name),
+		Description: localizedFromV12(cg.Description),
 		ParentID:    cg.ParentID,
 	})
 }
@@ -118,7 +118,7 @@ func convertV12Header(h *bmecat12.Header) *Header {
 			Language:    c.Language,
 			ID:          c.ID,
 			Version:     c.Version,
-			Name:        c.Name,
+			Name:        localizedFromV12(c.Name),
 			Currency:    c.Currency,
 			Territories: c.Territories,
 		}
@@ -149,18 +149,18 @@ func convertV12Product(a *bmecat12.Article) *Product {
 	}
 	if d := a.Details; d != nil {
 		out.GTIN = d.EAN
-		out.DescriptionShort = d.DescriptionShort
-		out.DescriptionLong = d.DescriptionLong
+		out.DescriptionShort = localizedFromV12(d.DescriptionShort)
+		out.DescriptionLong = localizedFromV12(d.DescriptionLong)
 		out.SupplierAltID = d.SupplierAltAID
 		out.ManufacturerID = d.ManufacturerAID
 		out.ManufacturerName = d.ManufacturerName
-		out.ManufacturerTypeDescr = d.ManufacturerTypeDescr
+		out.ManufacturerTypeDescr = localizedFromV12(d.ManufacturerTypeDescr)
 		out.ERPGroupBuyer = d.ERPGroupBuyer
 		out.ERPGroupSupplier = d.ERPGroupSupplier
 		out.DeliveryTime = d.DeliveryTime
-		out.Keywords = d.Keywords
-		out.Remarks = d.Remarks
-		out.Segments = d.Segments
+		out.Keywords = localizedSliceFromV12(d.Keywords)
+		out.Remarks = localizedFromV12(d.Remarks)
+		out.Segments = localizedSliceFromV12(d.Segments)
 		for _, b := range d.BuyerAIDs {
 			if b != nil {
 				out.BuyerIDs = append(out.BuyerIDs, &TypedValue{Type: b.Type, Value: b.Value})
@@ -202,14 +202,33 @@ func convertV12Product(a *bmecat12.Article) *Product {
 		for _, m := range mi.Mimes {
 			out.Mimes = append(out.Mimes, &Mime{
 				Type:    m.Type,
-				Source:  m.Source,
-				Descr:   m.Descr,
+				Source:  localizedFromV12(m.Source),
+				Descr:   localizedFromV12(m.Descr),
 				Purpose: m.Purpose,
 				Order:   m.Order,
 			})
 		}
 	}
 	return out
+}
+
+// localizedFromV12 lifts a scalar BMEcat 1.2 value into the neutral
+// LocalizedStrings. BMEcat 1.2 has no per-element lang attribute, so the result
+// carries a single language-less variant (or nil for an empty value).
+func localizedFromV12(s string) LocalizedStrings {
+	if s == "" {
+		return nil
+	}
+	return Localized(s)
+}
+
+// localizedSliceFromV12 lifts a list of scalar BMEcat 1.2 values (e.g. KEYWORD)
+// into the neutral LocalizedStrings, each as a language-less variant.
+func localizedSliceFromV12(values []string) LocalizedStrings {
+	if len(values) == 0 {
+		return nil
+	}
+	return Localized(values...)
 }
 
 func convertV12PriceDetails(pd *bmecat12.ArticlePriceDetails) *PriceDetails {
@@ -263,12 +282,12 @@ func convertV12Features(f *bmecat12.ArticleFeatures) *Features {
 	out := &Features{
 		SystemName: f.FeatureSystemName,
 		GroupID:    f.FeatureGroupID,
-		GroupName:  f.FeatureGroupName,
+		GroupName:  localizedFromV12(f.FeatureGroupName),
 	}
 	for _, ft := range f.Features {
 		out.Features = append(out.Features, &Feature{
-			Name:   ft.Name,
-			Values: ft.Values,
+			Name:   localizedFromV12(ft.Name),
+			Values: localizedSliceFromV12(ft.Values),
 			Unit:   ft.Unit,
 		})
 	}

--- a/adapter_v2005.go
+++ b/adapter_v2005.go
@@ -65,8 +65,8 @@ func (a *v2005Adapter) HandleCatalogGroup(cg *bmecat2005.CatalogGroup) error {
 	return a.catalogGroup.HandleCatalogGroup(&CatalogGroup{
 		Type:        cg.Type,
 		ID:          cg.ID,
-		Name:        cg.Name,
-		Description: cg.Description,
+		Name:        localizedFromV2005(cg.Name),
+		Description: localizedFromV2005(cg.Description),
 		ParentID:    cg.ParentID,
 		Order:       cg.Order,
 	})
@@ -79,8 +79,8 @@ func (a *v2005Adapter) HandleClassificationGroup(cg *bmecat2005.ClassificationGr
 	return a.classifGroup.HandleClassificationGroup(&ClassificationGroup{
 		Type:        cg.Type,
 		ID:          cg.ID,
-		Name:        cg.Name,
-		Description: cg.Description,
+		Name:        localizedFromV2005(cg.Name),
+		Description: localizedFromV2005(cg.Description),
 		ParentID:    cg.ParentID,
 	})
 }
@@ -107,7 +107,7 @@ func convertV2005Header(h *bmecat2005.Header) *Header {
 			Language:    c.Language,
 			ID:          c.ID,
 			Version:     c.Version,
-			Name:        c.Name,
+			Name:        localizedFromV2005(c.Name),
 			Currency:    c.Currency,
 			Territories: c.Territories,
 		}
@@ -138,18 +138,18 @@ func convertV2005Product(p *bmecat2005.Product) *Product {
 	}
 	if d := p.Details; d != nil {
 		out.GTIN = gtinFromV2005(d)
-		out.DescriptionShort = d.DescriptionShort
-		out.DescriptionLong = d.DescriptionLong
+		out.DescriptionShort = localizedFromV2005(d.DescriptionShort)
+		out.DescriptionLong = localizedFromV2005(d.DescriptionLong)
 		out.SupplierAltID = d.SupplierAltPID
 		out.ManufacturerID = d.ManufacturerPID
 		out.ManufacturerName = d.ManufacturerName
-		out.ManufacturerTypeDescr = d.ManufacturerTypeDescr
+		out.ManufacturerTypeDescr = localizedFromV2005(d.ManufacturerTypeDescr)
 		out.ERPGroupBuyer = d.ERPGroupBuyer
 		out.ERPGroupSupplier = d.ERPGroupSupplier
 		out.DeliveryTime = d.DeliveryTime
-		out.Keywords = d.Keywords
-		out.Remarks = d.Remarks
-		out.Segments = d.Segments
+		out.Keywords = localizedFromV2005(d.Keywords)
+		out.Remarks = localizedFromV2005(d.Remarks)
+		out.Segments = localizedFromV2005(d.Segments)
 		for _, b := range d.BuyerPIDs {
 			if b != nil {
 				out.BuyerIDs = append(out.BuyerIDs, &TypedValue{Type: b.Type, Value: b.Value})
@@ -191,12 +191,25 @@ func convertV2005Product(p *bmecat2005.Product) *Product {
 		for _, m := range mi.Mimes {
 			out.Mimes = append(out.Mimes, &Mime{
 				Type:    m.Type,
-				Source:  m.Source,
-				Descr:   m.Descr,
+				Source:  localizedFromV2005(m.Source),
+				Descr:   localizedFromV2005(m.Descr),
 				Purpose: m.Purpose,
 				Order:   m.Order,
 			})
 		}
+	}
+	return out
+}
+
+// localizedFromV2005 converts a bmecat2005 LocalizedStrings into the neutral
+// one, preserving variant order and language.
+func localizedFromV2005(in bmecat2005.LocalizedStrings) LocalizedStrings {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(LocalizedStrings, len(in))
+	for i, ls := range in {
+		out[i] = LocalizedString{Lang: ls.Lang, Value: ls.Value}
 	}
 	return out
 }
@@ -279,12 +292,12 @@ func convertV2005Features(f *bmecat2005.ProductFeatures) *Features {
 	out := &Features{
 		SystemName: f.FeatureSystemName,
 		GroupID:    f.FeatureGroupID,
-		GroupName:  f.FeatureGroupName,
+		GroupName:  localizedFromV2005(f.FeatureGroupName),
 	}
 	for _, ft := range f.Features {
 		out.Features = append(out.Features, &Feature{
-			Name:   ft.Name,
-			Values: ft.Values,
+			Name:   localizedFromV2005(ft.Name),
+			Values: localizedFromV2005(ft.Values),
 			Unit:   ft.Unit,
 		})
 	}

--- a/bmecat12/classification_group.go
+++ b/bmecat12/classification_group.go
@@ -7,12 +7,12 @@ import (
 type ClassificationSystem struct {
 	XMLName xml.Name `xml:"CLASSIFICATION_SYSTEM"`
 
-	Name        string                           `xml:"CLASSIFICATION_SYSTEM_NAME"`
-	FullName    string                           `xml:"CLASSIFICATION_SYSTEM_FULLNAME,omitempty"`
-	Version     string                           `xml:"CLASSIFICATION_SYSTEM_VERSION,omitempty"`
-	Description string                           `xml:"CLASSIFICATION_SYSTEM_DESCR,omitempty"`
-	Levels      int                              `xml:"CLASSIFICATION_SYSTEM_LEVELS,omitempty"`
-	LevelNames  []*ClassificationSystemLevelName `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAMES,omitempty"`
+	Name        string                         `xml:"CLASSIFICATION_SYSTEM_NAME"`
+	FullName    string                         `xml:"CLASSIFICATION_SYSTEM_FULLNAME,omitempty"`
+	Version     string                         `xml:"CLASSIFICATION_SYSTEM_VERSION,omitempty"`
+	Description string                         `xml:"CLASSIFICATION_SYSTEM_DESCR,omitempty"`
+	Levels      int                            `xml:"CLASSIFICATION_SYSTEM_LEVELS,omitempty"`
+	LevelNames  ClassificationSystemLevelNames `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAMES,omitempty"`
 	// ALLOWED_VALUES
 	// UNITS
 	// CLASSIFICATION_SYSTEM_FEATURE_TEMPLATES
@@ -22,6 +22,33 @@ type ClassificationSystem struct {
 // IsBlank returns true if there are no groups in the classification system.
 func (cs *ClassificationSystem) IsBlank() bool {
 	return cs == nil || len(cs.Groups) == 0
+}
+
+// ClassificationSystemLevelNames is the CLASSIFICATION_SYSTEM_LEVEL_NAMES
+// wrapper around the CLASSIFICATION_SYSTEM_LEVEL_NAME list. It marshals the
+// wrapper only when it holds entries, so an empty list emits nothing (the DTD
+// requires at least one name inside the wrapper).
+type ClassificationSystemLevelNames []*ClassificationSystemLevelName
+
+func (s ClassificationSystemLevelNames) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if len(s) == 0 {
+		return nil
+	}
+	type wrapper struct {
+		Names []*ClassificationSystemLevelName `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAME"`
+	}
+	return e.EncodeElement(wrapper{Names: s}, start)
+}
+
+func (s *ClassificationSystemLevelNames) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var w struct {
+		Names []*ClassificationSystemLevelName `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAME"`
+	}
+	if err := d.DecodeElement(&w, &start); err != nil {
+		return err
+	}
+	*s = w.Names
+	return nil
 }
 
 type ClassificationSystemLevelName struct {

--- a/bmecat2005/catalog_group.go
+++ b/bmecat2005/catalog_group.go
@@ -5,15 +5,15 @@ import "encoding/xml"
 type CatalogGroup struct {
 	XMLName xml.Name `xml:"CATALOG_STRUCTURE"`
 
-	Type        string  `xml:"type,attr,omitempty"`
-	ID          string  `xml:"GROUP_ID"`
-	Name        string  `xml:"GROUP_NAME"`
-	Description string  `xml:"GROUP_DESCRIPTION,omitempty"`
-	ParentID    *string `xml:"PARENT_ID,omitempty"`
-	Order       int     `xml:"GROUP_ORDER,omitempty"`
+	Type        string           `xml:"type,attr,omitempty"`
+	ID          string           `xml:"GROUP_ID"`
+	Name        LocalizedStrings `xml:"GROUP_NAME"`
+	Description LocalizedStrings `xml:"GROUP_DESCRIPTION,omitempty"`
+	ParentID    *string          `xml:"PARENT_ID,omitempty"`
+	Order       int              `xml:"GROUP_ORDER,omitempty"`
 	// MIME_INFO
 	// USER_DEFINED_EXTENSIONS
-	Keywords []string `xml:"KEYWORD,omitempty"`
+	Keywords LocalizedStrings `xml:"KEYWORD,omitempty"`
 }
 
 func (cg *CatalogGroup) IsRoot() bool {

--- a/bmecat2005/classification_group.go
+++ b/bmecat2005/classification_group.go
@@ -8,9 +8,9 @@ type ClassificationSystem struct {
 	XMLName xml.Name `xml:"CLASSIFICATION_SYSTEM"`
 
 	Name        string                           `xml:"CLASSIFICATION_SYSTEM_NAME"`
-	FullName    string                           `xml:"CLASSIFICATION_SYSTEM_FULLNAME,omitempty"`
+	FullName    LocalizedStrings                 `xml:"CLASSIFICATION_SYSTEM_FULLNAME,omitempty"`
 	Version     string                           `xml:"CLASSIFICATION_SYSTEM_VERSION,omitempty"`
-	Description string                           `xml:"CLASSIFICATION_SYSTEM_DESCR,omitempty"`
+	Description LocalizedStrings                 `xml:"CLASSIFICATION_SYSTEM_DESCR,omitempty"`
 	Levels      int                              `xml:"CLASSIFICATION_SYSTEM_LEVELS,omitempty"`
 	LevelNames  []*ClassificationSystemLevelName `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAMES,omitempty"`
 	// ALLOWED_VALUES
@@ -27,7 +27,10 @@ func (cs *ClassificationSystem) IsBlank() bool {
 type ClassificationSystemLevelName struct {
 	XMLName xml.Name `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAME"`
 
-	Level int    `xml:"level,attr"`
+	Level int `xml:"level,attr"`
+	// Lang is the xml lang attribute; CLASSIFICATION_SYSTEM_LEVEL_NAME is
+	// localized in 2005, so the same level may appear once per language.
+	Lang  string `xml:"lang,attr,omitempty"`
 	Value string `xml:",chardata"`
 }
 
@@ -37,15 +40,15 @@ type ClassificationGroup struct {
 	Type        string                       `xml:"type,attr,omitempty"`
 	Level       *int                         `xml:"level,attr,omitempty"`
 	ID          string                       `xml:"CLASSIFICATION_GROUP_ID"`
-	Name        string                       `xml:"CLASSIFICATION_GROUP_NAME"`
-	Description string                       `xml:"CLASSIFICATION_GROUP_DESCR,omitempty"`
+	Name        LocalizedStrings             `xml:"CLASSIFICATION_GROUP_NAME"`
+	Description LocalizedStrings             `xml:"CLASSIFICATION_GROUP_DESCR,omitempty"`
 	Synonyms    []ClassificationGroupSynonym `xml:"CLASSIFICATION_GROUP_SYNONYMS,omitempty"`
 	// CLASSIFICATION_GROUP_FEATURE_TEMPLATES
 	ParentID string `xml:"CLASSIFICATION_GROUP_PARENT_ID,omitempty"`
 }
 
 type ClassificationGroupSynonym struct {
-	Value string `xml:"SYNONYM,omitempty"`
+	Value LocalizedStrings `xml:"SYNONYM,omitempty"`
 }
 
 func (cg *ClassificationGroup) IsNode() bool {

--- a/bmecat2005/classification_group.go
+++ b/bmecat2005/classification_group.go
@@ -7,12 +7,12 @@ import (
 type ClassificationSystem struct {
 	XMLName xml.Name `xml:"CLASSIFICATION_SYSTEM"`
 
-	Name        string                           `xml:"CLASSIFICATION_SYSTEM_NAME"`
-	FullName    LocalizedStrings                 `xml:"CLASSIFICATION_SYSTEM_FULLNAME,omitempty"`
-	Version     string                           `xml:"CLASSIFICATION_SYSTEM_VERSION,omitempty"`
-	Description LocalizedStrings                 `xml:"CLASSIFICATION_SYSTEM_DESCR,omitempty"`
-	Levels      int                              `xml:"CLASSIFICATION_SYSTEM_LEVELS,omitempty"`
-	LevelNames  []*ClassificationSystemLevelName `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAMES,omitempty"`
+	Name        string                         `xml:"CLASSIFICATION_SYSTEM_NAME"`
+	FullName    LocalizedStrings               `xml:"CLASSIFICATION_SYSTEM_FULLNAME,omitempty"`
+	Version     string                         `xml:"CLASSIFICATION_SYSTEM_VERSION,omitempty"`
+	Description LocalizedStrings               `xml:"CLASSIFICATION_SYSTEM_DESCR,omitempty"`
+	Levels      int                            `xml:"CLASSIFICATION_SYSTEM_LEVELS,omitempty"`
+	LevelNames  ClassificationSystemLevelNames `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAMES,omitempty"`
 	// ALLOWED_VALUES
 	// UNITS
 	// CLASSIFICATION_SYSTEM_FEATURE_TEMPLATES
@@ -22,6 +22,33 @@ type ClassificationSystem struct {
 // IsBlank returns true if there are no groups in the classification system.
 func (cs *ClassificationSystem) IsBlank() bool {
 	return cs == nil || len(cs.Groups) == 0
+}
+
+// ClassificationSystemLevelNames is the CLASSIFICATION_SYSTEM_LEVEL_NAMES
+// wrapper around the CLASSIFICATION_SYSTEM_LEVEL_NAME list. It marshals the
+// wrapper only when it holds entries, so an empty list emits nothing (the DTD
+// requires at least one name inside the wrapper).
+type ClassificationSystemLevelNames []*ClassificationSystemLevelName
+
+func (s ClassificationSystemLevelNames) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if len(s) == 0 {
+		return nil
+	}
+	type wrapper struct {
+		Names []*ClassificationSystemLevelName `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAME"`
+	}
+	return e.EncodeElement(wrapper{Names: s}, start)
+}
+
+func (s *ClassificationSystemLevelNames) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var w struct {
+		Names []*ClassificationSystemLevelName `xml:"CLASSIFICATION_SYSTEM_LEVEL_NAME"`
+	}
+	if err := d.DecodeElement(&w, &start); err != nil {
+		return err
+	}
+	*s = w.Names
+	return nil
 }
 
 type ClassificationSystemLevelName struct {

--- a/bmecat2005/coverage_test.go
+++ b/bmecat2005/coverage_test.go
@@ -131,7 +131,7 @@ func TestReadCatalogGroupDispatch(t *testing.T) {
 	if want, have := "1", cg.ID; want != have {
 		t.Errorf("want group ID %q, have %q", want, have)
 	}
-	if want, have := "Hardware", cg.Name; want != have {
+	if want, have := "Hardware", cg.Name.Value(); want != have {
 		t.Errorf("want group name %q, have %q", want, have)
 	}
 	if !cg.IsNode() {
@@ -193,7 +193,7 @@ func TestReadISO8859_1(t *testing.T) {
 	if want, have := 1, len(h.catalogGroups); want != have {
 		t.Fatalf("want %d catalog group(s), have %d", want, have)
 	}
-	if want, have := "Müller", h.catalogGroups[0].Name; want != have {
+	if want, have := "Müller", h.catalogGroups[0].Name.Value(); want != have {
 		t.Errorf("want decoded group name %q, have %q", want, have)
 	}
 }
@@ -222,7 +222,7 @@ func TestReadGBKChinese(t *testing.T) {
 	if want, have := 1, len(h.catalogGroups); want != have {
 		t.Fatalf("want %d catalog group(s), have %d", want, have)
 	}
-	if want, have := "电子产品", h.catalogGroups[0].Name; want != have {
+	if want, have := "电子产品", h.catalogGroups[0].Name.Value(); want != have {
 		t.Errorf("want decoded group name %q, have %q", want, have)
 	}
 }
@@ -252,7 +252,7 @@ func TestReaderProgress(t *testing.T) {
 
 func TestWriterProgress(t *testing.T) {
 	products := []*bmecat2005.Product{
-		{SupplierPID: "1000", Details: &bmecat2005.ProductDetails{DescriptionShort: "Test"}},
+		{SupplierPID: "1000", Details: &bmecat2005.ProductDetails{DescriptionShort: bmecat2005.Localized("Test")}},
 	}
 	cw := catalogWriter{tx: bmecat2005.NewCatalog, header: testHeader, products: products}
 
@@ -315,7 +315,7 @@ func TestRoundTrip(t *testing.T) {
 	if h.header == nil {
 		t.Fatal("want a header after round trip, have nil")
 	}
-	if want, have := testHeader.Catalog.Name, h.header.Catalog.Name; want != have {
+	if want, have := testHeader.Catalog.Name.Value(), h.header.Catalog.Name.Value(); want != have {
 		t.Errorf("want catalog name %q, have %q", want, have)
 	}
 	if want, have := 1, len(h.products); want != have {

--- a/bmecat2005/header.go
+++ b/bmecat2005/header.go
@@ -28,15 +28,15 @@ type Header struct {
 type Catalog struct {
 	XMLName xml.Name `xml:"CATALOG"`
 
-	Language    string      `xml:"LANGUAGE"`
-	ID          string      `xml:"CATALOG_ID"`
-	Version     string      `xml:"CATALOG_VERSION"`
-	Name        string      `xml:"CATALOG_NAME,omitempty"`
-	GenDate     *DateTime   `xml:"DATETIME,omitempty"`
-	Territories []string    `xml:"TERRITORY,omitempty"`
-	Currency    string      `xml:"CURRENCY,omitempty"`
-	MimeRoot    string      `xml:"MIME_ROOT,omitempty"`
-	PriceFlags  []PriceFlag `xml:"PRICE_FLAG,omitempty"`
+	Language    string           `xml:"LANGUAGE"`
+	ID          string           `xml:"CATALOG_ID"`
+	Version     string           `xml:"CATALOG_VERSION"`
+	Name        LocalizedStrings `xml:"CATALOG_NAME,omitempty"`
+	GenDate     *DateTime        `xml:"DATETIME,omitempty"`
+	Territories []string         `xml:"TERRITORY,omitempty"`
+	Currency    string           `xml:"CURRENCY,omitempty"`
+	MimeRoot    string           `xml:"MIME_ROOT,omitempty"`
+	PriceFlags  []PriceFlag      `xml:"PRICE_FLAG,omitempty"`
 }
 
 const (
@@ -70,24 +70,24 @@ type Buyer struct {
 }
 
 type Address struct {
-	Type      string `xml:"type,attr"`
-	Name      string `xml:"NAME,omitempty"`
-	Name2     string `xml:"NAME2,omitempty"`
-	Name3     string `xml:"NAME3,omitempty"`
-	Contact   string `xml:"CONTACT,omitempty"`
-	Street    string `xml:"STREET,omitempty"`
-	Zip       string `xml:"ZIP,omitempty"`
-	BoxNo     string `xml:"BOXNO,omitempty"`
-	ZipBox    string `xml:"ZIPBOX,omitempty"`
-	City      string `xml:"CITY,omitempty"`
-	State     string `xml:"STATE,omitempty"`
-	Country   string `xml:"COUNTRY,omitempty"`
-	Phone     string `xml:"PHONE,omitempty"`
-	Fax       string `xml:"FAX,omitempty"`
-	Email     string `xml:"EMAIL,omitempty"`
-	PublicKey string `xml:"PUBLIC_KEY,omitempty"`
-	URL       string `xml:"URL,omitempty"`
-	Remarks   string `xml:"ADDRESS_REMARKS,omitempty"`
+	Type      string           `xml:"type,attr"`
+	Name      LocalizedStrings `xml:"NAME,omitempty"`
+	Name2     LocalizedStrings `xml:"NAME2,omitempty"`
+	Name3     LocalizedStrings `xml:"NAME3,omitempty"`
+	Contact   LocalizedStrings `xml:"CONTACT,omitempty"`
+	Street    LocalizedStrings `xml:"STREET,omitempty"`
+	Zip       LocalizedStrings `xml:"ZIP,omitempty"`
+	BoxNo     LocalizedStrings `xml:"BOXNO,omitempty"`
+	ZipBox    LocalizedStrings `xml:"ZIPBOX,omitempty"`
+	City      LocalizedStrings `xml:"CITY,omitempty"`
+	State     LocalizedStrings `xml:"STATE,omitempty"`
+	Country   LocalizedStrings `xml:"COUNTRY,omitempty"`
+	Phone     LocalizedStrings `xml:"PHONE,omitempty"`
+	Fax       LocalizedStrings `xml:"FAX,omitempty"`
+	Email     string           `xml:"EMAIL,omitempty"`
+	PublicKey string           `xml:"PUBLIC_KEY,omitempty"`
+	URL       string           `xml:"URL,omitempty"`
+	Remarks   LocalizedStrings `xml:"ADDRESS_REMARKS,omitempty"`
 }
 
 const (

--- a/bmecat2005/localized.go
+++ b/bmecat2005/localized.go
@@ -1,0 +1,97 @@
+package bmecat2005
+
+import "encoding/xml"
+
+// LocalizedString is a single language variant of a character-data element that
+// carries an xml-style lang attribute, such as DESCRIPTION_SHORT or
+// DESCRIPTION_LONG. Lang is empty when the source element has no lang attribute.
+type LocalizedString struct {
+	Lang  string `xml:"lang,attr,omitempty"`
+	Value string `xml:",chardata"`
+}
+
+// LocalizedStrings is an ordered list of language variants of the same element.
+// BMEcat allows an element such as DESCRIPTION_SHORT to appear once per
+// language; the variants are kept in document order.
+type LocalizedStrings []LocalizedString
+
+// Localized returns a LocalizedStrings holding one entry per value, each with no
+// language attribute. It is the convenient constructor for the common
+// single-language case (one value) and for a plain list of values.
+func Localized(values ...string) LocalizedStrings {
+	out := make(LocalizedStrings, len(values))
+	for i, v := range values {
+		out[i] = LocalizedString{Value: v}
+	}
+	return out
+}
+
+// Get returns the value for the given language. It returns the value of the
+// exact-match variant if one exists, otherwise the first variant in document
+// order, and the empty string when there are no variants.
+func (s LocalizedStrings) Get(lang string) string {
+	for _, ls := range s {
+		if ls.Lang == lang {
+			return ls.Value
+		}
+	}
+	return s.Value()
+}
+
+// Value returns the first variant's value in document order, or the empty
+// string when there are no variants.
+func (s LocalizedStrings) Value() string {
+	if len(s) > 0 {
+		return s[0].Value
+	}
+	return ""
+}
+
+// All returns every value for the given language, in document order. It is the
+// multi-valued counterpart of Get, for elements that legitimately repeat (such
+// as KEYWORD): a flat list carries both several distinct values and their
+// language variants, and All filters to one language. When no entry matches the
+// language it falls back to every value (so single-language data tagged without
+// a lang is still returned), and it returns nil when there are no entries.
+func (s LocalizedStrings) All(lang string) []string {
+	var out []string
+	for _, ls := range s {
+		if ls.Lang == lang {
+			out = append(out, ls.Value)
+		}
+	}
+	if out == nil && len(s) > 0 {
+		for _, ls := range s {
+			out = append(out, ls.Value)
+		}
+	}
+	return out
+}
+
+// Set adds or replaces the variant for the given language in place.
+func (s *LocalizedStrings) Set(lang, value string) {
+	for i := range *s {
+		if (*s)[i].Lang == lang {
+			(*s)[i].Value = value
+			return
+		}
+	}
+	*s = append(*s, LocalizedString{Lang: lang, Value: value})
+}
+
+// MarshalXML emits one element per variant, carrying a lang attribute only for
+// variants whose Lang is set. When there are no variants it still emits a single
+// empty element, so a required element such as DESCRIPTION_SHORT is preserved;
+// callers that want the element omitted when empty tag the field with
+// ",omitempty", which suppresses this method for an empty slice.
+func (s LocalizedStrings) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if len(s) == 0 {
+		return e.EncodeElement("", start)
+	}
+	for _, ls := range s {
+		if err := e.EncodeElement(ls, start); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/bmecat2005/localized_test.go
+++ b/bmecat2005/localized_test.go
@@ -1,0 +1,201 @@
+package bmecat2005_test
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/olivere/bmecat/bmecat2005"
+)
+
+func TestLocalizedStringsMarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		details bmecat2005.ProductDetails
+		want    []string // substrings that must appear
+		absent  []string // substrings that must not appear
+	}{
+		{
+			name:    "single variant has no lang attribute",
+			details: bmecat2005.ProductDetails{DescriptionShort: bmecat2005.Localized("Widget")},
+			want:    []string{"<DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT>"},
+			absent:  []string{"DESCRIPTION_SHORT lang="},
+		},
+		{
+			name: "multiple variants emit one element each with lang",
+			details: bmecat2005.ProductDetails{DescriptionShort: bmecat2005.LocalizedStrings{
+				{Lang: "deu", Value: "Hallo"},
+				{Lang: "eng", Value: "Hi"},
+			}},
+			want: []string{
+				`<DESCRIPTION_SHORT lang="deu">Hallo</DESCRIPTION_SHORT>`,
+				`<DESCRIPTION_SHORT lang="eng">Hi</DESCRIPTION_SHORT>`,
+			},
+		},
+		{
+			name:    "empty required short still emits an element",
+			details: bmecat2005.ProductDetails{},
+			want:    []string{"<DESCRIPTION_SHORT></DESCRIPTION_SHORT>"},
+		},
+		{
+			name:    "empty optional long is omitted",
+			details: bmecat2005.ProductDetails{DescriptionShort: bmecat2005.Localized("Widget")},
+			absent:  []string{"DESCRIPTION_LONG"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := xml.Marshal(&tt.details)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(b)
+			for _, w := range tt.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("want %q in:\n%s", w, got)
+				}
+			}
+			for _, a := range tt.absent {
+				if strings.Contains(got, a) {
+					t.Errorf("did not want %q in:\n%s", a, got)
+				}
+			}
+		})
+	}
+}
+
+func TestLocalizedStringsUnmarshal(t *testing.T) {
+	const in = `<PRODUCT_DETAILS>
+  <DESCRIPTION_SHORT lang="deu">Hallo</DESCRIPTION_SHORT>
+  <DESCRIPTION_SHORT lang="eng">Hi</DESCRIPTION_SHORT>
+  <DESCRIPTION_SHORT>Plain</DESCRIPTION_SHORT>
+</PRODUCT_DETAILS>`
+	var d bmecat2005.ProductDetails
+	if err := xml.Unmarshal([]byte(in), &d); err != nil {
+		t.Fatal(err)
+	}
+	want := bmecat2005.LocalizedStrings{
+		{Lang: "deu", Value: "Hallo"},
+		{Lang: "eng", Value: "Hi"},
+		{Lang: "", Value: "Plain"},
+	}
+	if len(d.DescriptionShort) != len(want) {
+		t.Fatalf("got %d variants, want %d: %+v", len(d.DescriptionShort), len(want), d.DescriptionShort)
+	}
+	for i := range want {
+		if d.DescriptionShort[i] != want[i] {
+			t.Errorf("variant %d = %+v, want %+v", i, d.DescriptionShort[i], want[i])
+		}
+	}
+	if have := d.DescriptionShort.Get("eng"); have != "Hi" {
+		t.Errorf("Get(eng) = %q, want %q", have, "Hi")
+	}
+	if have := d.DescriptionShort.Value(); have != "Hallo" {
+		t.Errorf("Value() = %q, want %q", have, "Hallo")
+	}
+}
+
+// TestNewLocalizedFieldsRoundTrip exercises the broader set of dtMLSTRING fields
+// (beyond the descriptions) added in this change: address parts, MIME source/alt,
+// feature descr/value-details/variant, catalog-group keywords, classification
+// group synonyms and classification level names. Each carries two languages and
+// must survive a marshal/unmarshal round trip with both variants intact.
+func TestNewLocalizedFieldsRoundTrip(t *testing.T) {
+	ml := func(de, en string) bmecat2005.LocalizedStrings {
+		return bmecat2005.LocalizedStrings{{Lang: "deu", Value: de}, {Lang: "eng", Value: en}}
+	}
+
+	t.Run("address and mime", func(t *testing.T) {
+		in := &bmecat2005.Supplier{
+			Name:    "SupplyCo",
+			Address: &bmecat2005.Address{Type: "supplier", City: ml("Köln", "Cologne"), Street: ml("Domstraße", "Cathedral St")},
+			MimeInfo: &bmecat2005.MimeInfo{Mimes: []*bmecat2005.Mime{
+				{Type: "application/pdf", Source: ml("blatt-de.pdf", "sheet-en.pdf"), Alt: ml("Datenblatt", "Datasheet"), Purpose: "data_sheet"},
+			}},
+		}
+		var out bmecat2005.Supplier
+		roundTrip(t, in, &out)
+		if got := out.Address.City.Get("eng"); got != "Cologne" {
+			t.Errorf("City Get(eng) = %q, want Cologne", got)
+		}
+		if got := out.Address.Street.Get("deu"); got != "Domstraße" {
+			t.Errorf("Street Get(deu) = %q, want Domstraße", got)
+		}
+		m := out.MimeInfo.Mimes[0]
+		if got := m.Source.Get("eng"); got != "sheet-en.pdf" {
+			t.Errorf("MIME source Get(eng) = %q, want sheet-en.pdf", got)
+		}
+		if got := m.Alt.Get("deu"); got != "Datenblatt" {
+			t.Errorf("MIME alt Get(deu) = %q, want Datenblatt", got)
+		}
+	})
+
+	t.Run("feature descr, value details and variants", func(t *testing.T) {
+		in := &bmecat2005.Feature{
+			Name:         ml("Farbe", "Color"),
+			Descr:        ml("Die Farbe", "The color"),
+			ValueDetails: ml("rot-ish", "red-ish"),
+			Variants: []*bmecat2005.FeatureVariants{{Variants: []*bmecat2005.FeatureVariant{
+				{Value: ml("rot", "red"), SupplierAIDSupplement: "-R"},
+			}}},
+		}
+		var out bmecat2005.Feature
+		roundTrip(t, in, &out)
+		if got := out.Descr.Get("eng"); got != "The color" {
+			t.Errorf("FDESCR Get(eng) = %q, want The color", got)
+		}
+		if got := out.ValueDetails.Get("deu"); got != "rot-ish" {
+			t.Errorf("FVALUE_DETAILS Get(deu) = %q, want rot-ish", got)
+		}
+		if got := out.Variants[0].Variants[0].Value.Get("eng"); got != "red" {
+			t.Errorf("variant FVALUE Get(eng) = %q, want red", got)
+		}
+	})
+
+	t.Run("catalog group keywords", func(t *testing.T) {
+		in := &bmecat2005.CatalogGroup{ID: "1", Name: ml("Werkzeug", "Tools"), Keywords: ml("Schraube", "Screw")}
+		var out bmecat2005.CatalogGroup
+		roundTrip(t, in, &out)
+		if got := out.Keywords.All("eng"); len(got) != 1 || got[0] != "Screw" {
+			t.Errorf("catalog group keywords All(eng) = %v, want [Screw]", got)
+		}
+	})
+
+	t.Run("classification synonyms round trip", func(t *testing.T) {
+		in := &bmecat2005.ClassificationGroup{
+			ID:       "1",
+			Name:     ml("Werkzeug", "Tools"),
+			Synonyms: []bmecat2005.ClassificationGroupSynonym{{Value: ml("Gerät", "Device")}},
+		}
+		var out bmecat2005.ClassificationGroup
+		roundTrip(t, in, &out)
+		if got := out.Synonyms[0].Value.Get("eng"); got != "Device" {
+			t.Errorf("synonym Get(eng) = %q, want Device", got)
+		}
+	})
+
+	t.Run("level name carries lang", func(t *testing.T) {
+		// NOTE: ClassificationSystemLevelName round-trips only one direction here
+		// because of a pre-existing wrapper/XMLName mismatch on the LevelNames
+		// field (see follow-up); we assert the lang attribute is emitted.
+		in := &bmecat2005.ClassificationSystemLevelName{Level: 1, Lang: "eng", Value: "Main group"}
+		b, err := xml.Marshal(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := string(b); !strings.Contains(got, `lang="eng"`) || !strings.Contains(got, ">Main group<") {
+			t.Errorf("level name marshal = %s, want lang and value", got)
+		}
+	})
+}
+
+func roundTrip(t *testing.T, in, out any) {
+	t.Helper()
+	b, err := xml.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := xml.Unmarshal(b, out); err != nil {
+		t.Fatalf("unmarshal: %v\nxml: %s", err, b)
+	}
+}

--- a/bmecat2005/localized_test.go
+++ b/bmecat2005/localized_test.go
@@ -174,17 +174,28 @@ func TestNewLocalizedFieldsRoundTrip(t *testing.T) {
 		}
 	})
 
-	t.Run("level name carries lang", func(t *testing.T) {
-		// NOTE: ClassificationSystemLevelName round-trips only one direction here
-		// because of a pre-existing wrapper/XMLName mismatch on the LevelNames
-		// field (see follow-up); we assert the lang attribute is emitted.
-		in := &bmecat2005.ClassificationSystemLevelName{Level: 1, Lang: "eng", Value: "Main group"}
+	t.Run("level names round trip with lang", func(t *testing.T) {
+		in := &bmecat2005.ClassificationSystem{
+			Name: "udf-1.0",
+			LevelNames: []*bmecat2005.ClassificationSystemLevelName{
+				{Level: 1, Lang: "deu", Value: "Hauptgruppe"},
+				{Level: 1, Lang: "eng", Value: "Main group"},
+			},
+		}
 		b, err := xml.Marshal(in)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got := string(b); !strings.Contains(got, `lang="eng"`) || !strings.Contains(got, ">Main group<") {
-			t.Errorf("level name marshal = %s, want lang and value", got)
+		// The level names must be wrapped in CLASSIFICATION_SYSTEM_LEVEL_NAMES.
+		if !strings.Contains(string(b), "<CLASSIFICATION_SYSTEM_LEVEL_NAMES>") {
+			t.Errorf("missing CLASSIFICATION_SYSTEM_LEVEL_NAMES wrapper:\n%s", b)
+		}
+		var out bmecat2005.ClassificationSystem
+		if err := xml.Unmarshal(b, &out); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.LevelNames) != 2 || out.LevelNames[1].Lang != "eng" || out.LevelNames[1].Value != "Main group" {
+			t.Errorf("level names round trip = %+v", out.LevelNames)
 		}
 	})
 }

--- a/bmecat2005/mime.go
+++ b/bmecat2005/mime.go
@@ -36,12 +36,12 @@ type MimeInfo struct {
 type Mime struct {
 	XMLName xml.Name `xml:"MIME"`
 
-	Type    string `xml:"MIME_TYPE,omitempty"`
-	Source  string `xml:"MIME_SOURCE"`
-	Descr   string `xml:"MIME_DESCR,omitempty"`
-	Alt     string `xml:"MIME_ALT,omitempty"`
-	Purpose string `xml:"MIME_PURPOSE,omitempty"`
-	Order   int    `xml:"MIME_ORDER,omitempty"`
+	Type    string           `xml:"MIME_TYPE,omitempty"`
+	Source  LocalizedStrings `xml:"MIME_SOURCE"`
+	Descr   LocalizedStrings `xml:"MIME_DESCR,omitempty"`
+	Alt     LocalizedStrings `xml:"MIME_ALT,omitempty"`
+	Purpose string           `xml:"MIME_PURPOSE,omitempty"`
+	Order   int              `xml:"MIME_ORDER,omitempty"`
 }
 
 // ThumbnailSource returns the URL of the thumbnail image.
@@ -49,7 +49,7 @@ type Mime struct {
 func (m *MimeInfo) ThumbnailSource() string {
 	for _, mime := range m.Mimes {
 		if mime.Purpose == MimePurposeThumbnail {
-			return mime.Source
+			return mime.Source.Value()
 		}
 	}
 	return ""
@@ -60,7 +60,7 @@ func (m *MimeInfo) ThumbnailSource() string {
 func (m *MimeInfo) NormalSource() string {
 	for _, mime := range m.Mimes {
 		if mime.Purpose == MimePurposeNormal {
-			return mime.Source
+			return mime.Source.Value()
 		}
 	}
 	return ""
@@ -71,7 +71,7 @@ func (m *MimeInfo) NormalSource() string {
 func (m *MimeInfo) DetailSource() string {
 	for _, mime := range m.Mimes {
 		if mime.Purpose == MimePurposeDetail {
-			return mime.Source
+			return mime.Source.Value()
 		}
 	}
 	return ""
@@ -82,7 +82,7 @@ func (m *MimeInfo) DetailSource() string {
 func (m *MimeInfo) DataSheetSource() string {
 	for _, mime := range m.Mimes {
 		if mime.Purpose == MimePurposeDataSheet {
-			return mime.Source
+			return mime.Source.Value()
 		}
 	}
 	return ""
@@ -93,7 +93,7 @@ func (m *MimeInfo) DataSheetSource() string {
 func (m *MimeInfo) LogoSource() string {
 	for _, mime := range m.Mimes {
 		if mime.Purpose == MimePurposeLogo {
-			return mime.Source
+			return mime.Source.Value()
 		}
 	}
 	return ""
@@ -104,7 +104,7 @@ func (m *MimeInfo) LogoSource() string {
 func (m *MimeInfo) IconSource() string {
 	for _, mime := range m.Mimes {
 		if mime.Purpose == MimePurposeIcon {
-			return mime.Source
+			return mime.Source.Value()
 		}
 	}
 	return ""
@@ -115,7 +115,7 @@ func (m *MimeInfo) IconSource() string {
 func (m *MimeInfo) SafetyDataSheetSource() string {
 	for _, mime := range m.Mimes {
 		if mime.Purpose == MimePurposeSafetyDataSheet {
-			return mime.Source
+			return mime.Source.Value()
 		}
 	}
 	return ""

--- a/bmecat2005/model_test.go
+++ b/bmecat2005/model_test.go
@@ -243,13 +243,13 @@ func TestAgreementStartEndDate(t *testing.T) {
 func TestMimeInfoSources(t *testing.T) {
 	mi := &MimeInfo{
 		Mimes: []*Mime{
-			{Purpose: MimePurposeThumbnail, Source: "thumb.jpg"},
-			{Purpose: MimePurposeNormal, Source: "normal.jpg"},
-			{Purpose: MimePurposeDetail, Source: "detail.jpg"},
-			{Purpose: MimePurposeDataSheet, Source: "sheet.pdf"},
-			{Purpose: MimePurposeLogo, Source: "logo.png"},
-			{Purpose: MimePurposeIcon, Source: "icon.png"},
-			{Purpose: MimePurposeSafetyDataSheet, Source: "safety.pdf"},
+			{Purpose: MimePurposeThumbnail, Source: Localized("thumb.jpg")},
+			{Purpose: MimePurposeNormal, Source: Localized("normal.jpg")},
+			{Purpose: MimePurposeDetail, Source: Localized("detail.jpg")},
+			{Purpose: MimePurposeDataSheet, Source: Localized("sheet.pdf")},
+			{Purpose: MimePurposeLogo, Source: Localized("logo.png")},
+			{Purpose: MimePurposeIcon, Source: Localized("icon.png")},
+			{Purpose: MimePurposeSafetyDataSheet, Source: Localized("safety.pdf")},
 		},
 	}
 	cases := []struct {

--- a/bmecat2005/product.go
+++ b/bmecat2005/product.go
@@ -58,8 +58,8 @@ type InternationalPID struct {
 }
 
 type ProductDetails struct {
-	DescriptionShort  string              `xml:"DESCRIPTION_SHORT"`
-	DescriptionLong   string              `xml:"DESCRIPTION_LONG,omitempty"`
+	DescriptionShort  LocalizedStrings    `xml:"DESCRIPTION_SHORT"`
+	DescriptionLong   LocalizedStrings    `xml:"DESCRIPTION_LONG,omitempty"`
 	InternationalPIDs []*InternationalPID `xml:"INTERNATIONAL_PID,omitempty"`
 	// EAN is accepted when reading 2005 documents that still use the
 	// 1.2-compatible EAN element. The DTD treats INTERNATIONAL_PID and EAN as
@@ -70,14 +70,14 @@ type ProductDetails struct {
 	BuyerPIDs               []*BuyerPID                     `xml:"BUYER_PID,omitempty"`
 	ManufacturerPID         string                          `xml:"MANUFACTURER_PID,omitempty"`
 	ManufacturerName        string                          `xml:"MANUFACTURER_NAME,omitempty"`
-	ManufacturerTypeDescr   string                          `xml:"MANUFACTURER_TYPE_DESCR,omitempty"`
+	ManufacturerTypeDescr   LocalizedStrings                `xml:"MANUFACTURER_TYPE_DESCR,omitempty"`
 	ERPGroupBuyer           string                          `xml:"ERP_GROUP_BUYER,omitempty"`
 	ERPGroupSupplier        string                          `xml:"ERP_GROUP_SUPPLIER,omitempty"`
 	DeliveryTime            *int                            `xml:"DELIVERY_TIME,omitempty"`
 	SpecialTreatmentClasses []*ProductSpecialTreatmentClass `xml:"SPECIAL_TREATMENT_CLASS,omitempty"`
-	Keywords                []string                        `xml:"KEYWORD,omitempty"`
-	Remarks                 string                          `xml:"REMARKS,omitempty"`
-	Segments                []string                        `xml:"SEGMENT,omitempty"`
+	Keywords                LocalizedStrings                `xml:"KEYWORD,omitempty"`
+	Remarks                 LocalizedStrings                `xml:"REMARKS,omitempty"`
+	Segments                LocalizedStrings                `xml:"SEGMENT,omitempty"`
 	ProductOrder            int                             `xml:"PRODUCT_ORDER,omitempty"`
 	ProductStatus           []*ProductStatus                `xml:"PRODUCT_STATUS,omitempty"`
 }
@@ -88,10 +88,10 @@ type BuyerPID struct {
 }
 
 type ProductFeatures struct {
-	FeatureSystemName string     `xml:"REFERENCE_FEATURE_SYSTEM_NAME,omitempty"`
-	FeatureGroupID    string     `xml:"REFERENCE_FEATURE_GROUP_ID,omitempty"`
-	FeatureGroupName  string     `xml:"REFERENCE_FEATURE_GROUP_NAME,omitempty"`
-	Features          []*Feature `xml:"FEATURE,omitempty"`
+	FeatureSystemName string           `xml:"REFERENCE_FEATURE_SYSTEM_NAME,omitempty"`
+	FeatureGroupID    string           `xml:"REFERENCE_FEATURE_GROUP_ID,omitempty"`
+	FeatureGroupName  LocalizedStrings `xml:"REFERENCE_FEATURE_GROUP_NAME,omitempty"`
+	Features          []*Feature       `xml:"FEATURE,omitempty"`
 }
 
 func (pf ProductFeatures) IsEclass() bool {
@@ -111,13 +111,13 @@ func (pf ProductFeatures) Version() string {
 }
 
 type Feature struct {
-	Name         string             `xml:"FNAME"`
+	Name         LocalizedStrings   `xml:"FNAME"`
 	Variants     []*FeatureVariants `xml:"VARIANTS,omitempty"`
-	Values       []string           `xml:"FVALUE,omitempty"`
+	Values       LocalizedStrings   `xml:"FVALUE,omitempty"`
 	Unit         string             `xml:"FUNIT,omitempty"`
 	Order        int                `xml:"FORDER,omitempty"`
-	Descr        string             `xml:"FDESCR,omitempty"`
-	ValueDetails string             `xml:"FVALUE_DETAILS,omitempty"`
+	Descr        LocalizedStrings   `xml:"FDESCR,omitempty"`
+	ValueDetails LocalizedStrings   `xml:"FVALUE_DETAILS,omitempty"`
 }
 
 type FeatureVariants struct {
@@ -126,8 +126,8 @@ type FeatureVariants struct {
 }
 
 type FeatureVariant struct {
-	Value                 string `xml:"FVALUE"`
-	SupplierAIDSupplement string `xml:"SUPPLIER_AID_SUPPLEMENT"`
+	Value                 LocalizedStrings `xml:"FVALUE"`
+	SupplierAIDSupplement string           `xml:"SUPPLIER_AID_SUPPLEMENT"`
 }
 
 type ProductOrderDetails struct {

--- a/bmecat2005/writer_stream_test.go
+++ b/bmecat2005/writer_stream_test.go
@@ -39,7 +39,7 @@ func TestStreamProducts(t *testing.T) {
 			for i := range n {
 				p := &bmecat2005.Product{
 					SupplierPID: fmt.Sprintf("P%04d", i),
-					Details:     &bmecat2005.ProductDetails{DescriptionShort: "x"},
+					Details:     &bmecat2005.ProductDetails{DescriptionShort: bmecat2005.Localized("x")},
 				}
 				if err := yield(p); err != nil {
 					return err
@@ -71,7 +71,7 @@ func TestStreamProductsSkipsNil(t *testing.T) {
 			if err := yield(nil); err != nil {
 				return err
 			}
-			return yield(&bmecat2005.Product{SupplierPID: "1", Details: &bmecat2005.ProductDetails{DescriptionShort: "x"}})
+			return yield(&bmecat2005.Product{SupplierPID: "1", Details: &bmecat2005.ProductDetails{DescriptionShort: bmecat2005.Localized("x")}})
 		},
 	}
 
@@ -91,7 +91,7 @@ func TestStreamProductsProducerError(t *testing.T) {
 	cw := funcCatalog{
 		header: testHeader,
 		produce: func(yield func(*bmecat2005.Product) error) error {
-			if err := yield(&bmecat2005.Product{SupplierPID: "1", Details: &bmecat2005.ProductDetails{DescriptionShort: "x"}}); err != nil {
+			if err := yield(&bmecat2005.Product{SupplierPID: "1", Details: &bmecat2005.ProductDetails{DescriptionShort: bmecat2005.Localized("x")}}); err != nil {
 				return err
 			}
 			return boom
@@ -113,7 +113,7 @@ func TestStreamProductsContextCancel(t *testing.T) {
 	cw := funcCatalog{
 		header: testHeader,
 		produce: func(yield func(*bmecat2005.Product) error) error {
-			return yield(&bmecat2005.Product{SupplierPID: "1", Details: &bmecat2005.ProductDetails{DescriptionShort: "x"}})
+			return yield(&bmecat2005.Product{SupplierPID: "1", Details: &bmecat2005.ProductDetails{DescriptionShort: bmecat2005.Localized("x")}})
 		},
 	}
 

--- a/bmecat2005/writer_test.go
+++ b/bmecat2005/writer_test.go
@@ -29,7 +29,7 @@ var testHeader = &bmecat2005.Header{
 		Language:    "deu",
 		ID:          "CAT1",
 		Version:     "1.0",
-		Name:        "Katalogbezeichnung",
+		Name:        bmecat2005.Localized("Katalogbezeichnung"),
 		GenDate:     bmecat2005.NewDateTime(bmecat2005.DateTimeGenerationDate, time.Date(2000, 10, 24, 20, 38, 0o0, 0, time.UTC)),
 		Territories: []string{"DE", "AT"},
 		Currency:    "EUR",
@@ -56,11 +56,11 @@ var testHeader = &bmecat2005.Header{
 		Name: "SupplyCo Ltd.",
 		Address: &bmecat2005.Address{
 			Type: "supplier",
-			City: "London",
+			City: bmecat2005.Localized("London"),
 		},
 		MimeInfo: &bmecat2005.MimeInfo{
 			Mimes: []*bmecat2005.Mime{
-				{Type: "image/jpeg", Source: "supplier_logo.jpg", Purpose: "logo"},
+				{Type: "image/jpeg", Source: bmecat2005.Localized("supplier_logo.jpg"), Purpose: "logo"},
 			},
 		},
 	},
@@ -138,13 +138,13 @@ func (w catalogWriter) Products(ctx context.Context) (<-chan *bmecat2005.Product
 func sampleClassificationSystem() *bmecat2005.ClassificationSystem {
 	return &bmecat2005.ClassificationSystem{
 		Name:     "udf_Supplier-1.0",
-		FullName: testHeader.Supplier.Name,
+		FullName: bmecat2005.Localized(testHeader.Supplier.Name),
 		Groups: []*bmecat2005.ClassificationGroup{
-			{ID: "1", Name: "Hardware", Type: "node"},
-			{ID: "2", Name: "Notebook", ParentID: "1", Type: "node"},
-			{ID: "3", Name: "Desktop", ParentID: "1", Type: "node"},
-			{ID: "4", Name: "PC", ParentID: "2", Type: "leaf"},
-			{ID: "5", Name: "Mac", ParentID: "2", Type: "leaf"},
+			{ID: "1", Name: bmecat2005.Localized("Hardware"), Type: "node"},
+			{ID: "2", Name: bmecat2005.Localized("Notebook"), ParentID: "1", Type: "node"},
+			{ID: "3", Name: bmecat2005.Localized("Desktop"), ParentID: "1", Type: "node"},
+			{ID: "4", Name: bmecat2005.Localized("PC"), ParentID: "2", Type: "leaf"},
+			{ID: "5", Name: bmecat2005.Localized("Mac"), ParentID: "2", Type: "leaf"},
 		},
 	}
 }
@@ -156,8 +156,8 @@ func sampleProduct() *bmecat2005.Product {
 	return &bmecat2005.Product{
 		SupplierPID: "1000",
 		Details: &bmecat2005.ProductDetails{
-			DescriptionShort: `Apple MacBook Pro 13"`,
-			DescriptionLong:  `Das Kraftpaket unter den Notebooks.`,
+			DescriptionShort: bmecat2005.Localized(`Apple MacBook Pro 13"`),
+			DescriptionLong:  bmecat2005.Localized(`Das Kraftpaket unter den Notebooks.`),
 			InternationalPIDs: []*bmecat2005.InternationalPID{
 				{Type: "gtin", Value: "8712670911213"},
 			},
@@ -171,8 +171,8 @@ func sampleProduct() *bmecat2005.Product {
 			SpecialTreatmentClasses: []*bmecat2005.ProductSpecialTreatmentClass{
 				{Type: "GGVS", Value: "1201"},
 			},
-			Keywords: []string{"Notebook", "Hardware"},
-			Remarks:  "Noch heute bestellen!",
+			Keywords: bmecat2005.Localized("Notebook", "Hardware"),
+			Remarks:  bmecat2005.Localized("Noch heute bestellen!"),
 			ProductStatus: []*bmecat2005.ProductStatus{
 				{Type: bmecat2005.ProductStatusCoreProduct, Value: "Kernsortiment"},
 			},
@@ -183,8 +183,8 @@ func sampleProduct() *bmecat2005.Product {
 				FeatureGroupID:    "19010203",
 				Features: []*bmecat2005.Feature{
 					{
-						Name:   "Netzspannung",
-						Values: []string{"110", "220"},
+						Name:   bmecat2005.Localized("Netzspannung"),
+						Values: bmecat2005.Localized("110", "220"),
 						Unit:   "VLT",
 					},
 				},
@@ -233,8 +233,8 @@ func sampleProduct() *bmecat2005.Product {
 			Mimes: []*bmecat2005.Mime{
 				{
 					Type:    "image/jpeg",
-					Source:  "55-K-31.jpg",
-					Descr:   "Frontansicht des Notebooks",
+					Source:  bmecat2005.Localized("55-K-31.jpg"),
+					Descr:   bmecat2005.Localized("Frontansicht des Notebooks"),
 					Purpose: bmecat2005.MimePurposeNormal,
 				},
 			},
@@ -298,7 +298,7 @@ func TestWriteNewCatalog(t *testing.T) {
 func TestWriteNewCatalogWithBlankClassificationSystem(t *testing.T) {
 	classSys := &bmecat2005.ClassificationSystem{
 		Name:     "udf_Supplier-1.0",
-		FullName: testHeader.Supplier.Name,
+		FullName: bmecat2005.Localized(testHeader.Supplier.Name),
 		Groups:   []*bmecat2005.ClassificationGroup{}, // no groups
 	}
 	cw := catalogWriter{

--- a/doc.go
+++ b/doc.go
@@ -23,6 +23,28 @@ The neutral model exposes the fields the two versions have in common. In
 particular [Product.GTIN] unifies the 1.2 EAN element and the 2005
 INTERNATIONAL_PID element behind a single accessor.
 
+BMEcat 2005 lets many text elements repeat once per language (the spec's
+dtMLSTRING type). Those neutral fields are [LocalizedStrings], keeping every
+variant in document order: [LocalizedStrings.Get] picks one by language (falling
+back to the first variant), [LocalizedStrings.Value] returns the first,
+[LocalizedStrings.All] returns every value for a language (for elements that
+repeat, such as KEYWORD), and [Localized] builds the common single-language
+value. Every element the 2005 schema types as dtMLSTRING is covered: on the
+neutral model the catalog name; product short/long description, manufacturer type
+description, keywords, remarks and segments; feature group name, feature names
+and values; MIME source and description — and, in the bmecat2005 package,
+additionally address parts, MIME alt, feature descriptions/value-details/variant
+values, catalog-group keywords, classification-group synonyms and classification
+system level names. Identifiers and codes typed as plain strings (e.g.
+MANUFACTURER_NAME, FUNIT, the classification system name) stay scalar.
+
+BMEcat 1.2 has no per-element lang attribute, so the bmecat12 structs stay
+scalar: reading 1.2 yields a single language-less variant, and writing the
+neutral model to 1.2 emits the variant matching the catalog language (falling
+back to the first), which is lossy for multi-language data. The lang attribute is
+written (in 2005) only for variants that set a language, so single-language
+catalogs round-trip unchanged.
+
 Prices are exposed two ways. [Product.Prices] is a flat list of every price
 block, convenient when the grouping does not matter. [Product.PriceDetails]
 preserves the ARTICLE_PRICE_DETAILS / PRODUCT_PRICE_DETAILS wrapper grouping,

--- a/example_test.go
+++ b/example_test.go
@@ -13,12 +13,12 @@ import (
 type catalogPrinter struct{}
 
 func (catalogPrinter) HandleHeader(h *bmecat.Header) error {
-	fmt.Printf("Catalog %q (BMEcat %s)\n", h.Catalog.Name, h.Version)
+	fmt.Printf("Catalog %q (BMEcat %s)\n", h.Catalog.Name.Value(), h.Version)
 	return nil
 }
 
 func (catalogPrinter) HandleProduct(p *bmecat.Product) error {
-	fmt.Printf("- %s: %s (GTIN %s)\n", p.ID, p.DescriptionShort, p.GTIN)
+	fmt.Printf("- %s: %s (GTIN %s)\n", p.ID, p.DescriptionShort.Value(), p.GTIN)
 	return nil
 }
 
@@ -86,7 +86,7 @@ func (springCatalog) Header() *bmecat.Header {
 			Language: "deu",
 			ID:       "CAT1",
 			Version:  "1.0",
-			Name:     "Spring Catalog",
+			Name:     bmecat.Localized("Spring Catalog"),
 		},
 		Supplier: &bmecat.Supplier{Name: "SupplyCo"},
 	}
@@ -97,7 +97,7 @@ func (springCatalog) Products(ctx context.Context) (<-chan *bmecat.Product, <-ch
 		{
 			ID:               "1000",
 			GTIN:             "1234567890123",
-			DescriptionShort: "Widget",
+			DescriptionShort: bmecat.Localized("Widget"),
 			OrderUnit:        "PCE",
 			Prices: []*bmecat.Price{
 				{Type: "net_customer", Amount: 9.99, Currency: "EUR"},
@@ -142,14 +142,14 @@ func ExampleWriter() {
 // the producer streams products by calling yield, with no channels to manage.
 func ExampleWriter_writeFunc() {
 	header := &bmecat.Header{
-		Catalog:  &bmecat.Catalog{Language: "deu", ID: "CAT1", Version: "1.0", Name: "Spring Catalog"},
+		Catalog:  &bmecat.Catalog{Language: "deu", ID: "CAT1", Version: "1.0", Name: bmecat.Localized("Spring Catalog")},
 		Supplier: &bmecat.Supplier{Name: "SupplyCo"},
 	}
 	products := []*bmecat.Product{
 		{
 			ID:               "1000",
 			GTIN:             "1234567890123",
-			DescriptionShort: "Widget",
+			DescriptionShort: bmecat.Localized("Widget"),
 			OrderUnit:        "PCE",
 			Prices:           []*bmecat.Price{{Type: "net_customer", Amount: 9.99, Currency: "EUR"}},
 		},

--- a/localized.go
+++ b/localized.go
@@ -1,0 +1,79 @@
+package bmecat
+
+// LocalizedString is the version-neutral view of a single language variant of a
+// character-data element that carries a lang attribute, such as
+// DESCRIPTION_SHORT or DESCRIPTION_LONG. Lang is empty when the source element
+// has no lang attribute.
+type LocalizedString struct {
+	Lang  string
+	Value string
+}
+
+// LocalizedStrings is an ordered list of language variants of the same element,
+// preserved in document order. It lets a consumer pick the variant matching a
+// configured language rather than relying on element order.
+type LocalizedStrings []LocalizedString
+
+// Localized returns a LocalizedStrings holding one entry per value, each with no
+// language attribute. It is the convenient constructor for the common
+// single-language case (one value) and for a plain list of values.
+func Localized(values ...string) LocalizedStrings {
+	out := make(LocalizedStrings, len(values))
+	for i, v := range values {
+		out[i] = LocalizedString{Value: v}
+	}
+	return out
+}
+
+// Get returns the value for the given language. It returns the value of the
+// exact-match variant if one exists, otherwise the first variant in document
+// order, and the empty string when there are no variants.
+func (s LocalizedStrings) Get(lang string) string {
+	for _, ls := range s {
+		if ls.Lang == lang {
+			return ls.Value
+		}
+	}
+	return s.Value()
+}
+
+// Value returns the first variant's value in document order, or the empty
+// string when there are no variants.
+func (s LocalizedStrings) Value() string {
+	if len(s) > 0 {
+		return s[0].Value
+	}
+	return ""
+}
+
+// All returns every value for the given language, in document order. It is the
+// multi-valued counterpart of Get, for elements that legitimately repeat (such
+// as KEYWORD): a flat list carries both several distinct values and their
+// language variants, and All filters to one language. When no entry matches the
+// language it falls back to every value (so single-language data tagged without
+// a lang is still returned), and it returns nil when there are no entries.
+func (s LocalizedStrings) All(lang string) []string {
+	var out []string
+	for _, ls := range s {
+		if ls.Lang == lang {
+			out = append(out, ls.Value)
+		}
+	}
+	if out == nil && len(s) > 0 {
+		for _, ls := range s {
+			out = append(out, ls.Value)
+		}
+	}
+	return out
+}
+
+// Set adds or replaces the variant for the given language in place.
+func (s *LocalizedStrings) Set(lang, value string) {
+	for i := range *s {
+		if (*s)[i].Lang == lang {
+			(*s)[i].Value = value
+			return
+		}
+	}
+	*s = append(*s, LocalizedString{Lang: lang, Value: value})
+}

--- a/localized_test.go
+++ b/localized_test.go
@@ -1,0 +1,327 @@
+package bmecat_test
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/olivere/bmecat"
+)
+
+func TestLocalizedAccessors(t *testing.T) {
+	multi := bmecat.LocalizedStrings{
+		{Lang: "deu", Value: "Hallo"},
+		{Lang: "eng", Value: "Hi"},
+		{Lang: "deu", Value: "Servus"},
+	}
+	tests := []struct {
+		name string
+		in   bmecat.LocalizedStrings
+		lang string
+		want string
+	}{
+		{"exact match returns first such", multi, "eng", "Hi"},
+		{"no match falls back to first", multi, "fra", "Hallo"},
+		{"empty slice", nil, "deu", ""},
+		{"empty lang matches attr-free entry", bmecat.Localized("Plain"), "", "Plain"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if have := tt.in.Get(tt.lang); have != tt.want {
+				t.Errorf("Get(%q) = %q, want %q", tt.lang, have, tt.want)
+			}
+		})
+	}
+
+	if have := multi.Value(); have != "Hallo" {
+		t.Errorf("Value() = %q, want %q", have, "Hallo")
+	}
+	if have := bmecat.LocalizedStrings(nil).Value(); have != "" {
+		t.Errorf("Value() on empty = %q, want empty", have)
+	}
+
+	// All returns every value for a language, falling back to all values when
+	// none match (so language-less data is still returned).
+	if have, want := multi.All("deu"), []string{"Hallo", "Servus"}; !reflect.DeepEqual(have, want) {
+		t.Errorf("All(deu) = %v, want %v", have, want)
+	}
+	if have, want := multi.All("fra"), []string{"Hallo", "Hi", "Servus"}; !reflect.DeepEqual(have, want) {
+		t.Errorf("All(fra) fallback = %v, want %v", have, want)
+	}
+	if have := bmecat.LocalizedStrings(nil).All("deu"); have != nil {
+		t.Errorf("All on empty = %v, want nil", have)
+	}
+
+	if have := bmecat.Localized("a", "b"); !reflect.DeepEqual(have, bmecat.LocalizedStrings{{Value: "a"}, {Value: "b"}}) {
+		t.Errorf("Localized(a, b) = %+v, want two attr-free entries", have)
+	}
+}
+
+func TestLocalizedSet(t *testing.T) {
+	var s bmecat.LocalizedStrings
+	s.Set("deu", "Hallo")
+	s.Set("eng", "Hi")
+	if want := (bmecat.LocalizedStrings{{Lang: "deu", Value: "Hallo"}, {Lang: "eng", Value: "Hi"}}); !reflect.DeepEqual(s, want) {
+		t.Fatalf("after adds = %+v, want %+v", s, want)
+	}
+	s.Set("deu", "Servus") // replaces in place
+	if want := (bmecat.LocalizedStrings{{Lang: "deu", Value: "Servus"}, {Lang: "eng", Value: "Hi"}}); !reflect.DeepEqual(s, want) {
+		t.Fatalf("after replace = %+v, want %+v", s, want)
+	}
+}
+
+// multiLang2005 is a 2005 catalog whose localized elements carry two languages
+// each, across the spread of fields the neutral model exposes.
+const multiLang2005 = `<?xml version="1.0"?>
+<BMECAT version="2005" xmlns="http://www.bmecat.org/bmecat/2005">
+  <HEADER>
+    <CATALOG>
+      <LANGUAGE>deu</LANGUAGE>
+      <CATALOG_ID>C</CATALOG_ID>
+      <CATALOG_VERSION>1</CATALOG_VERSION>
+      <CATALOG_NAME lang="deu">Katalog</CATALOG_NAME>
+      <CATALOG_NAME lang="eng">Catalog</CATALOG_NAME>
+    </CATALOG>
+  </HEADER>
+  <T_NEW_CATALOG>
+    <PRODUCT>
+      <SUPPLIER_PID>1</SUPPLIER_PID>
+      <PRODUCT_DETAILS>
+        <DESCRIPTION_SHORT lang="deu">Hallo</DESCRIPTION_SHORT>
+        <DESCRIPTION_SHORT lang="eng">Hi</DESCRIPTION_SHORT>
+        <DESCRIPTION_LONG lang="deu">Langer Text</DESCRIPTION_LONG>
+        <MANUFACTURER_TYPE_DESCR lang="deu">Typ</MANUFACTURER_TYPE_DESCR>
+        <MANUFACTURER_TYPE_DESCR lang="eng">Type</MANUFACTURER_TYPE_DESCR>
+        <KEYWORD lang="deu">Schraube</KEYWORD>
+        <KEYWORD lang="eng">Screw</KEYWORD>
+        <REMARKS lang="deu">Hinweis</REMARKS>
+      </PRODUCT_DETAILS>
+      <PRODUCT_FEATURES>
+        <REFERENCE_FEATURE_SYSTEM_NAME>ECLASS-5.1</REFERENCE_FEATURE_SYSTEM_NAME>
+        <REFERENCE_FEATURE_GROUP_NAME lang="deu">Gruppe</REFERENCE_FEATURE_GROUP_NAME>
+        <REFERENCE_FEATURE_GROUP_NAME lang="eng">Group</REFERENCE_FEATURE_GROUP_NAME>
+        <FEATURE>
+          <FNAME lang="deu">Farbe</FNAME>
+          <FNAME lang="eng">Color</FNAME>
+          <FVALUE lang="deu">rot</FVALUE>
+          <FVALUE lang="eng">red</FVALUE>
+        </FEATURE>
+      </PRODUCT_FEATURES>
+    </PRODUCT>
+  </T_NEW_CATALOG>
+</BMECAT>`
+
+// TestRead2005LocalizedFields verifies that 2005 preserves every language
+// variant across the localized fields, in document order.
+func TestRead2005LocalizedFields(t *testing.T) {
+	c := read(t, multiLang2005)
+	if c.header == nil || c.header.Catalog == nil {
+		t.Fatal("want catalog header")
+	}
+	if want, have := "Catalog", c.header.Catalog.Name.Get("eng"); want != have {
+		t.Errorf("Catalog.Name Get(eng) = %q, want %q", have, want)
+	}
+	if len(c.products) != 1 {
+		t.Fatalf("want one product, have %d", len(c.products))
+	}
+	p := c.products[0]
+
+	checks := []struct {
+		name string
+		have bmecat.LocalizedStrings
+		want bmecat.LocalizedStrings
+	}{
+		{"DescriptionShort", p.DescriptionShort, bmecat.LocalizedStrings{{Lang: "deu", Value: "Hallo"}, {Lang: "eng", Value: "Hi"}}},
+		{"DescriptionLong", p.DescriptionLong, bmecat.LocalizedStrings{{Lang: "deu", Value: "Langer Text"}}},
+		{"ManufacturerTypeDescr", p.ManufacturerTypeDescr, bmecat.LocalizedStrings{{Lang: "deu", Value: "Typ"}, {Lang: "eng", Value: "Type"}}},
+		{"Keywords", p.Keywords, bmecat.LocalizedStrings{{Lang: "deu", Value: "Schraube"}, {Lang: "eng", Value: "Screw"}}},
+		{"Remarks", p.Remarks, bmecat.LocalizedStrings{{Lang: "deu", Value: "Hinweis"}}},
+	}
+	for _, ck := range checks {
+		if !reflect.DeepEqual(ck.have, ck.want) {
+			t.Errorf("%s = %+v, want %+v", ck.name, ck.have, ck.want)
+		}
+	}
+
+	if len(p.Features) != 1 || len(p.Features[0].Features) != 1 {
+		t.Fatalf("want one feature, have %+v", p.Features)
+	}
+	if want, have := "Group", p.Features[0].GroupName.Get("eng"); want != have {
+		t.Errorf("GroupName Get(eng) = %q, want %q", have, want)
+	}
+	f := p.Features[0].Features[0]
+	if want, have := "Color", f.Name.Get("eng"); want != have {
+		t.Errorf("Feature.Name Get(eng) = %q, want %q", have, want)
+	}
+	if want, have := []string{"red"}, f.Values.All("eng"); !reflect.DeepEqual(want, have) {
+		t.Errorf("Feature.Values All(eng) = %v, want %v", have, want)
+	}
+}
+
+// TestRead2005RoundTrip writes a neutral catalog carrying multiple language
+// variants to 2005 and reads it back, asserting the variants survive unchanged.
+func TestWriteRead2005LocalizedRoundTrip(t *testing.T) {
+	header := fullHeader()
+	header.Catalog.Name = bmecat.LocalizedStrings{{Lang: "deu", Value: "Katalog"}, {Lang: "eng", Value: "Catalog"}}
+	product := &bmecat.Product{
+		ID:               "1",
+		DescriptionShort: bmecat.LocalizedStrings{{Lang: "deu", Value: "Hallo"}, {Lang: "eng", Value: "Hi"}},
+		Keywords:         bmecat.LocalizedStrings{{Lang: "deu", Value: "Schraube"}, {Lang: "eng", Value: "Screw"}},
+		Remarks:          bmecat.LocalizedStrings{{Lang: "deu", Value: "Hinweis"}},
+		Features: []*bmecat.Features{{
+			SystemName: "ECLASS-5.1",
+			GroupName:  bmecat.LocalizedStrings{{Lang: "deu", Value: "Gruppe"}, {Lang: "eng", Value: "Group"}},
+			Features: []*bmecat.Feature{{
+				Name:   bmecat.LocalizedStrings{{Lang: "deu", Value: "Farbe"}, {Lang: "eng", Value: "Color"}},
+				Values: bmecat.LocalizedStrings{{Lang: "deu", Value: "rot"}, {Lang: "eng", Value: "red"}},
+			}},
+		}},
+		Mimes: []*bmecat.Mime{{
+			Type:   "application/pdf",
+			Source: bmecat.LocalizedStrings{{Lang: "deu", Value: "blatt-de.pdf"}, {Lang: "eng", Value: "sheet-en.pdf"}},
+			Descr:  bmecat.LocalizedStrings{{Lang: "deu", Value: "Datenblatt"}, {Lang: "eng", Value: "Datasheet"}},
+		}},
+	}
+
+	var buf bytes.Buffer
+	cw := &sliceCatalogWriter{header: header, products: []*bmecat.Product{product}}
+	if err := bmecat.NewWriter(&buf, bmecat.WithVersion(bmecat.Version2005)).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+	c := read(t, buf.String())
+
+	if !reflect.DeepEqual(header.Catalog.Name, c.header.Catalog.Name) {
+		t.Errorf("Catalog.Name round trip: want %+v, have %+v", header.Catalog.Name, c.header.Catalog.Name)
+	}
+	if len(c.products) != 1 {
+		t.Fatalf("want one product, have %d", len(c.products))
+	}
+	got := c.products[0]
+	for _, ck := range []struct {
+		name       string
+		want, have bmecat.LocalizedStrings
+	}{
+		{"DescriptionShort", product.DescriptionShort, got.DescriptionShort},
+		{"Keywords", product.Keywords, got.Keywords},
+		{"Remarks", product.Remarks, got.Remarks},
+		{"GroupName", product.Features[0].GroupName, got.Features[0].GroupName},
+		{"Feature.Name", product.Features[0].Features[0].Name, got.Features[0].Features[0].Name},
+		{"Feature.Values", product.Features[0].Features[0].Values, got.Features[0].Features[0].Values},
+		{"Mime.Source", product.Mimes[0].Source, got.Mimes[0].Source},
+		{"Mime.Descr", product.Mimes[0].Descr, got.Mimes[0].Descr},
+	} {
+		if !reflect.DeepEqual(ck.want, ck.have) {
+			t.Errorf("%s round trip: want %+v, have %+v", ck.name, ck.want, ck.have)
+		}
+	}
+}
+
+// TestRead12Collapses confirms BMEcat 1.2, which has no per-element lang,
+// collapses repeated localized elements onto a single language-less value
+// (encoding/xml keeps the last) rather than inventing variants.
+func TestRead12Collapses(t *testing.T) {
+	const doc = `<?xml version="1.0"?>
+<BMECAT version="1.2">
+  <HEADER><CATALOG><LANGUAGE>deu</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER>
+  <T_NEW_CATALOG>
+    <ARTICLE>
+      <SUPPLIER_AID>1</SUPPLIER_AID>
+      <ARTICLE_DETAILS>
+        <DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT>
+        <KEYWORD>tool</KEYWORD>
+        <KEYWORD>widget</KEYWORD>
+      </ARTICLE_DETAILS>
+    </ARTICLE>
+  </T_NEW_CATALOG>
+</BMECAT>`
+	c := read(t, doc)
+	p := c.products[0]
+	if want, have := (bmecat.LocalizedStrings{{Value: "Widget"}}), p.DescriptionShort; !reflect.DeepEqual(want, have) {
+		t.Errorf("DescriptionShort = %+v, want %+v (language-less)", have, want)
+	}
+	// Both keywords survive (KEYWORD repeats in 1.2 too), each language-less.
+	if want, have := (bmecat.LocalizedStrings{{Value: "tool"}, {Value: "widget"}}), p.Keywords; !reflect.DeepEqual(want, have) {
+		t.Errorf("Keywords = %+v, want %+v", have, want)
+	}
+}
+
+// TestWrite12NoCatalogLanguage confirms that when no catalog language is
+// configured, writing multi-language neutral data to 1.2 collapses to the first
+// variant's language for both single and repeating elements, rather than leaking
+// every language's values into the single-language 1.2 document.
+func TestWrite12NoCatalogLanguage(t *testing.T) {
+	header := fullHeader()
+	header.Catalog.Language = "" // no declared language
+	product := &bmecat.Product{
+		ID:               "1",
+		DescriptionShort: bmecat.LocalizedStrings{{Lang: "deu", Value: "Hallo"}, {Lang: "eng", Value: "Hi"}},
+		Keywords:         bmecat.LocalizedStrings{{Lang: "deu", Value: "Schraube"}, {Lang: "eng", Value: "Screw"}},
+	}
+	var buf bytes.Buffer
+	cw := &sliceCatalogWriter{header: header, products: []*bmecat.Product{product}}
+	if err := bmecat.NewWriter(&buf, bmecat.WithVersion(bmecat.Version12)).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "<DESCRIPTION_SHORT>Hallo</DESCRIPTION_SHORT>") {
+		t.Errorf("want first-language description, got:\n%s", out)
+	}
+	// Only the first language's keyword, not both — no cross-language leak.
+	if !strings.Contains(out, "<KEYWORD>Schraube</KEYWORD>") || strings.Contains(out, "Screw") {
+		t.Errorf("want only the first-language keyword, got:\n%s", out)
+	}
+}
+
+// TestWriteAttrFreeDescription confirms a single-language description is written
+// without a spurious lang attribute, for both versions.
+func TestWriteAttrFreeDescription(t *testing.T) {
+	for _, version := range []bmecat.Version{bmecat.Version12, bmecat.Version2005} {
+		t.Run(version.String(), func(t *testing.T) {
+			product := &bmecat.Product{ID: "1", DescriptionShort: bmecat.Localized("Widget")}
+			var buf bytes.Buffer
+			cw := &sliceCatalogWriter{header: fullHeader(), products: []*bmecat.Product{product}}
+			if err := bmecat.NewWriter(&buf, bmecat.WithVersion(version)).Do(context.Background(), cw); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(buf.String(), "<DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT>") {
+				t.Errorf("want attr-free <DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT>, got:\n%s", buf.String())
+			}
+			if strings.Contains(buf.String(), "DESCRIPTION_SHORT lang=") {
+				t.Errorf("unexpected lang attribute on single-language description:\n%s", buf.String())
+			}
+		})
+	}
+}
+
+// TestWrite12PicksCatalogLanguage confirms that writing a multi-language neutral
+// catalog to 1.2 (which is single-language) emits the variant matching the
+// catalog's declared language, falling back to the first otherwise.
+func TestWrite12PicksCatalogLanguage(t *testing.T) {
+	header := fullHeader()
+	header.Catalog.Language = "eng"
+	product := &bmecat.Product{
+		ID:               "1",
+		DescriptionShort: bmecat.LocalizedStrings{{Lang: "deu", Value: "Hallo"}, {Lang: "eng", Value: "Hi"}},
+		Keywords:         bmecat.LocalizedStrings{{Lang: "deu", Value: "Schraube"}, {Lang: "eng", Value: "Screw"}},
+	}
+	var buf bytes.Buffer
+	cw := &sliceCatalogWriter{header: header, products: []*bmecat.Product{product}}
+	if err := bmecat.NewWriter(&buf, bmecat.WithVersion(bmecat.Version12)).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "<DESCRIPTION_SHORT>Hi</DESCRIPTION_SHORT>") {
+		t.Errorf("want English description, got:\n%s", out)
+	}
+	if strings.Contains(out, "Hallo") {
+		t.Errorf("did not want the German variant in 1.2 output:\n%s", out)
+	}
+	if !strings.Contains(out, "<KEYWORD>Screw</KEYWORD>") || strings.Contains(out, "Schraube") {
+		t.Errorf("want only the English keyword, got:\n%s", out)
+	}
+	if strings.Contains(out, "lang=") {
+		t.Errorf("1.2 output must not carry lang attributes:\n%s", out)
+	}
+}

--- a/model.go
+++ b/model.go
@@ -98,10 +98,11 @@ type Header struct {
 
 // Catalog is the version-neutral view of the CATALOG element.
 type Catalog struct {
-	Language    string
-	ID          string
-	Version     string
-	Name        string
+	Language string
+	ID       string
+	Version  string
+	// Name is CATALOG_NAME, a localized element in BMEcat 2005.
+	Name        LocalizedStrings
 	Currency    string
 	Territories []string
 }
@@ -131,18 +132,25 @@ type Product struct {
 	// INTERNATIONAL_PID (2005). See GTIN handling in the package docs.
 	GTIN string
 
-	DescriptionShort string
-	DescriptionLong  string
+	// DescriptionShort and DescriptionLong are DESCRIPTION_SHORT /
+	// DESCRIPTION_LONG. They hold every language variant the source document
+	// carries, in document order; use [LocalizedStrings.Get] to pick one by
+	// language or [LocalizedStrings.Value] for the first.
+	DescriptionShort LocalizedStrings
+	DescriptionLong  LocalizedStrings
 	SupplierAltID    string
 	ManufacturerID   string
 	ManufacturerName string
-	// ManufacturerTypeDescr is MANUFACTURER_TYPE_DESCR.
-	ManufacturerTypeDescr string
-	Keywords              []string
-	// Remarks is REMARKS.
-	Remarks string
-	// Segments is the list of SEGMENT values.
-	Segments []string
+	// ManufacturerTypeDescr is MANUFACTURER_TYPE_DESCR, localized in 2005.
+	ManufacturerTypeDescr LocalizedStrings
+	// Keywords are the KEYWORD values. Each KEYWORD is localized in 2005, so
+	// the flat list carries both distinct keywords and their language variants;
+	// use [LocalizedStrings.All] to get every keyword for a language.
+	Keywords LocalizedStrings
+	// Remarks is REMARKS, localized in 2005.
+	Remarks LocalizedStrings
+	// Segments are the SEGMENT values, localized in 2005 (see Keywords).
+	Segments LocalizedStrings
 
 	// ERPGroupBuyer and ERPGroupSupplier are ERP_GROUP_BUYER /
 	// ERP_GROUP_SUPPLIER.
@@ -215,8 +223,9 @@ type UDXField struct {
 type Features struct {
 	SystemName string
 	GroupID    string
-	GroupName  string
-	Features   []*Feature
+	// GroupName is REFERENCE_FEATURE_GROUP_NAME, localized in 2005.
+	GroupName LocalizedStrings
+	Features  []*Feature
 }
 
 // IsEclass reports whether the feature system is an eCl@ss classification.
@@ -241,9 +250,14 @@ func (f Features) Version() string {
 
 // Feature is the version-neutral view of a single FEATURE.
 type Feature struct {
-	Name   string
-	Values []string
-	Unit   string
+	// Name is FNAME, localized in 2005.
+	Name LocalizedStrings
+	// Values are the FVALUE entries, localized in 2005; a feature may carry
+	// several values, so use [LocalizedStrings.All] to get every value for a
+	// language.
+	Values LocalizedStrings
+	// Unit is FUNIT. It is not localized.
+	Unit string
 }
 
 // Price is the version-neutral view of an ARTICLE_PRICE (1.2) / PRODUCT_PRICE
@@ -279,19 +293,23 @@ type PriceDetails struct {
 
 // Mime is the version-neutral view of a MIME element.
 type Mime struct {
-	Type    string
-	Source  string
-	Descr   string
+	Type string
+	// Source is MIME_SOURCE and Descr is MIME_DESCR, both localized in 2005
+	// (e.g. a language-specific datasheet or image).
+	Source  LocalizedStrings
+	Descr   LocalizedStrings
 	Purpose string
 	Order   int
 }
 
 // CatalogGroup is the version-neutral view of a CATALOG_STRUCTURE element.
 type CatalogGroup struct {
-	Type        string
-	ID          string
-	Name        string
-	Description string
+	Type string
+	ID   string
+	// Name is GROUP_NAME and Description is GROUP_DESCRIPTION, both localized
+	// in 2005.
+	Name        LocalizedStrings
+	Description LocalizedStrings
 	ParentID    *string
 	Order       int
 }
@@ -303,10 +321,12 @@ func (cg *CatalogGroup) IsLeaf() bool { return cg.Type == "leaf" }
 // ClassificationGroup is the version-neutral view of a CLASSIFICATION_GROUP
 // element.
 type ClassificationGroup struct {
-	Type        string
-	ID          string
-	Name        string
-	Description string
+	Type string
+	ID   string
+	// Name is CLASSIFICATION_GROUP_NAME and Description is
+	// CLASSIFICATION_GROUP_DESCR, both localized in 2005.
+	Name        LocalizedStrings
+	Description LocalizedStrings
 	ParentID    string
 }
 
@@ -325,10 +345,14 @@ func (cg *ClassificationGroup) IsLeaf() bool { return cg.Type == "leaf" }
 // are not emitted; callers that need them should use the bmecat12 / bmecat2005
 // packages directly.
 type ClassificationSystem struct {
-	Name        string
-	FullName    string
+	// Name is CLASSIFICATION_SYSTEM_NAME, the system identifier (e.g.
+	// "ECLASS-5.1"). It is not localized.
+	Name string
+	// FullName is CLASSIFICATION_SYSTEM_FULLNAME and Description is
+	// CLASSIFICATION_SYSTEM_DESCR, both localized in 2005.
+	FullName    LocalizedStrings
 	Version     string
-	Description string
+	Description LocalizedStrings
 	Levels      int
 	LevelNames  []*ClassificationSystemLevelName
 	Groups      []*ClassificationGroup
@@ -345,5 +369,9 @@ func (cs *ClassificationSystem) IsBlank() bool {
 // level in the classification hierarchy.
 type ClassificationSystemLevelName struct {
 	Level int
-	Name  string
+	// Lang is the language of Name. CLASSIFICATION_SYSTEM_LEVEL_NAME is
+	// localized in 2005, so a level may have one entry per language (empty for
+	// 1.2 or single-language systems).
+	Lang string
+	Name string
 }

--- a/price_details_test.go
+++ b/price_details_test.go
@@ -146,7 +146,7 @@ func TestPriceDetailsRoundTrip(t *testing.T) {
 
 	product := &bmecat.Product{
 		ID:               "1000",
-		DescriptionShort: "Widget",
+		DescriptionShort: bmecat.Localized("Widget"),
 		PriceDetails: []*bmecat.PriceDetails{
 			{
 				ValidStart: &start,

--- a/reader_test.go
+++ b/reader_test.go
@@ -322,7 +322,7 @@ func TestReadCharset(t *testing.T) {
 	if c.header == nil || c.header.Catalog == nil {
 		t.Fatal("want catalog header, have nil")
 	}
-	if want, have := "Müller", c.header.Catalog.Name; want != have {
+	if want, have := "Müller", c.header.Catalog.Name.Value(); want != have {
 		t.Errorf("want decoded catalog name %q, have %q", want, have)
 	}
 }

--- a/writer_classification_test.go
+++ b/writer_classification_test.go
@@ -16,17 +16,17 @@ import (
 func classificationSystem() *bmecat.ClassificationSystem {
 	return &bmecat.ClassificationSystem{
 		Name:        "udf_Supplier-1.0",
-		FullName:    "Supplier classification 1.0",
+		FullName:    bmecat.Localized("Supplier classification 1.0"),
 		Version:     "1.0",
-		Description: "Supplier-defined classification",
+		Description: bmecat.Localized("Supplier-defined classification"),
 		Levels:      2,
 		LevelNames: []*bmecat.ClassificationSystemLevelName{
 			{Level: 1, Name: "Main group"},
 			{Level: 2, Name: "Sub group"},
 		},
 		Groups: []*bmecat.ClassificationGroup{
-			{Type: "node", ID: "1", Name: "Tools", Description: "All tools"},
-			{Type: "leaf", ID: "2", Name: "Widgets", Description: "Widget tools", ParentID: "1"},
+			{Type: "node", ID: "1", Name: bmecat.Localized("Tools"), Description: bmecat.Localized("All tools")},
+			{Type: "leaf", ID: "2", Name: bmecat.Localized("Widgets"), Description: bmecat.Localized("Widget tools"), ParentID: "1"},
 		},
 	}
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -66,18 +66,18 @@ func fullProduct() *bmecat.Product {
 	return &bmecat.Product{
 		ID:                      "1000",
 		GTIN:                    "1234567890123",
-		DescriptionShort:        "Widget",
-		DescriptionLong:         "A useful widget.",
+		DescriptionShort:        bmecat.Localized("Widget"),
+		DescriptionLong:         bmecat.Localized("A useful widget."),
 		SupplierAltID:           "ALT-1",
 		ManufacturerID:          "MPN-1",
 		ManufacturerName:        "Acme",
-		ManufacturerTypeDescr:   "Type-X",
+		ManufacturerTypeDescr:   bmecat.Localized("Type-X"),
 		ERPGroupBuyer:           "EB",
 		ERPGroupSupplier:        "ES",
 		DeliveryTime:            wInt(5),
-		Keywords:                []string{"tool", "widget"},
-		Remarks:                 "handle with care",
-		Segments:                []string{"SEG1"},
+		Keywords:                bmecat.Localized("tool", "widget"),
+		Remarks:                 bmecat.Localized("handle with care"),
+		Segments:                bmecat.Localized("SEG1"),
 		BuyerIDs:                []*bmecat.TypedValue{{Type: "buyer", Value: "B-1"}},
 		SpecialTreatmentClasses: []*bmecat.TypedValue{{Type: "GGVS", Value: "12"}},
 		Status:                  []*bmecat.TypedValue{{Type: "new", Value: "yes"}},
@@ -85,7 +85,7 @@ func fullProduct() *bmecat.Product {
 			SystemName: "ECLASS-5.1",
 			GroupID:    "19010203",
 			Features: []*bmecat.Feature{
-				{Name: "Voltage", Values: []string{"230"}, Unit: "VLT"},
+				{Name: bmecat.Localized("Voltage"), Values: bmecat.Localized("230"), Unit: "VLT"},
 			},
 		}},
 		OrderUnit:        "PCE",
@@ -97,7 +97,7 @@ func fullProduct() *bmecat.Product {
 		Prices:           []*bmecat.Price{price},
 		PriceDetails:     []*bmecat.PriceDetails{{Prices: []*bmecat.Price{price}}},
 		Mimes: []*bmecat.Mime{{
-			Type: "image/jpeg", Source: "img.jpg", Descr: "Image", Purpose: "normal", Order: 1,
+			Type: "image/jpeg", Source: bmecat.Localized("img.jpg"), Descr: bmecat.Localized("Image"), Purpose: "normal", Order: 1,
 		}},
 		UDX: []*bmecat.UDXField{{Name: "SYSTEM.CUSTOM_FIELD1", Value: "A"}},
 	}
@@ -110,7 +110,7 @@ func fullHeader() *bmecat.Header {
 			Language:    "deu",
 			ID:          "CAT1",
 			Version:     "1.0",
-			Name:        "Test Catalog",
+			Name:        bmecat.Localized("Test Catalog"),
 			Currency:    "EUR",
 			Territories: []string{"DE", "AT"},
 		},
@@ -251,7 +251,7 @@ func TestWriteStreaming(t *testing.T) {
 	const n = 1000
 	products := make([]*bmecat.Product, n)
 	for i := range products {
-		products[i] = &bmecat.Product{ID: fmt.Sprintf("P%04d", i), DescriptionShort: "x", OrderUnit: "PCE"}
+		products[i] = &bmecat.Product{ID: fmt.Sprintf("P%04d", i), DescriptionShort: bmecat.Localized("x"), OrderUnit: "PCE"}
 	}
 	cw := &sliceCatalogWriter{header: fullHeader(), products: products}
 
@@ -345,7 +345,7 @@ func TestWriteFuncStreaming(t *testing.T) {
 	err := bmecat.NewWriter(&buf, bmecat.WithVersion(bmecat.Version2005)).
 		WriteFunc(context.Background(), fullHeader(), func(yield func(*bmecat.Product) error) error {
 			for i := range n {
-				p := &bmecat.Product{ID: fmt.Sprintf("P%04d", i), DescriptionShort: "x", OrderUnit: "PCE"}
+				p := &bmecat.Product{ID: fmt.Sprintf("P%04d", i), DescriptionShort: bmecat.Localized("x"), OrderUnit: "PCE"}
 				if err := yield(p); err != nil {
 					return err
 				}
@@ -374,7 +374,7 @@ func TestWriteFuncSkipsNil(t *testing.T) {
 			if err := yield(nil); err != nil {
 				return err
 			}
-			return yield(&bmecat.Product{ID: "1", DescriptionShort: "x", OrderUnit: "PCE"})
+			return yield(&bmecat.Product{ID: "1", DescriptionShort: bmecat.Localized("x"), OrderUnit: "PCE"})
 		})
 	if err != nil {
 		t.Fatal(err)

--- a/writer_v12.go
+++ b/writer_v12.go
@@ -47,7 +47,7 @@ func (c *v12CatalogWriter) Language() string {
 // the Writer to the bmecat12 type, or returns nil to omit CLASSIFICATION_SYSTEM
 // when none was configured (or it carries no groups).
 func (c *v12CatalogWriter) ClassificationSystem() *bmecat12.ClassificationSystem {
-	return neutralClassificationSystemToV12(c.classification)
+	return neutralClassificationSystemToV12(c.classification, c.Language())
 }
 
 // Articles bridges the neutral product stream to the bmecat12 article stream:
@@ -102,7 +102,7 @@ func (c *v12CatalogWriter) Articles(ctx context.Context) (<-chan *bmecat12.Artic
 					continue
 				}
 				select {
-				case out <- neutralProductToV12(p):
+				case out <- neutralProductToV12(p, c.Language()):
 				case <-ctx.Done():
 					errc <- ctx.Err()
 					return
@@ -116,19 +116,25 @@ func (c *v12CatalogWriter) Articles(ctx context.Context) (<-chan *bmecat12.Artic
 // neutralClassificationSystemToV12 converts the neutral classification system
 // to the bmecat12 type. It returns nil for a nil or blank system, so the writer
 // omits CLASSIFICATION_SYSTEM exactly as it does for a native bmecat12 source.
-func neutralClassificationSystemToV12(cs *ClassificationSystem) *bmecat12.ClassificationSystem {
+func neutralClassificationSystemToV12(cs *ClassificationSystem, lang string) *bmecat12.ClassificationSystem {
 	if cs.IsBlank() {
 		return nil
 	}
 	out := &bmecat12.ClassificationSystem{
 		Name:        cs.Name,
-		FullName:    cs.FullName,
+		FullName:    mlToV12(cs.FullName, lang),
 		Version:     cs.Version,
-		Description: cs.Description,
+		Description: mlToV12(cs.Description, lang),
 		Levels:      cs.Levels,
 	}
 	for _, ln := range cs.LevelNames {
 		if ln == nil {
+			continue
+		}
+		// 1.2 has no per-element lang. Drop variants in a language other than the
+		// catalog's so a multi-language level is not duplicated; keep language-less
+		// entries always.
+		if ln.Lang != "" && lang != "" && ln.Lang != lang {
 			continue
 		}
 		out.LevelNames = append(out.LevelNames, &bmecat12.ClassificationSystemLevelName{
@@ -143,8 +149,8 @@ func neutralClassificationSystemToV12(cs *ClassificationSystem) *bmecat12.Classi
 		out.Groups = append(out.Groups, &bmecat12.ClassificationGroup{
 			Type:        g.Type,
 			ID:          g.ID,
-			Name:        g.Name,
-			Description: g.Description,
+			Name:        mlToV12(g.Name, lang),
+			Description: mlToV12(g.Description, lang),
 			ParentID:    g.ParentID,
 		})
 	}
@@ -161,7 +167,7 @@ func neutralHeaderToV12(h *Header) *bmecat12.Header {
 			Language:    c.Language,
 			ID:          c.ID,
 			Version:     c.Version,
-			Name:        c.Name,
+			Name:        mlToV12(c.Name, c.Language),
 			Currency:    c.Currency,
 			Territories: c.Territories,
 		}
@@ -181,24 +187,56 @@ func neutralHeaderToV12(h *Header) *bmecat12.Header {
 	return out
 }
 
-func neutralProductToV12(p *Product) *bmecat12.Article {
+// collapseLangV12 resolves the single language a BMEcat 1.2 (single-language)
+// document should carry: the requested catalog language if any variant uses it,
+// otherwise the first variant's own language. Both v12 collapse helpers resolve
+// the language the same way, so a single value and a repeating list stay in the
+// same language even when no catalog language is configured.
+func collapseLangV12(in LocalizedStrings, lang string) string {
+	for _, ls := range in {
+		if ls.Lang == lang {
+			return lang
+		}
+	}
+	if len(in) > 0 {
+		return in[0].Lang
+	}
+	return lang
+}
+
+// mlToV12 collapses a neutral LocalizedStrings to a single BMEcat 1.2 scalar
+// value. BMEcat 1.2 has no per-element lang attribute, so it emits the variant
+// matching the catalog language, falling back to the first variant. Writing a
+// multi-language neutral catalog to 1.2 is therefore lossy by design.
+func mlToV12(in LocalizedStrings, lang string) string {
+	return in.Get(collapseLangV12(in, lang))
+}
+
+// mlSliceToV12 collapses a neutral LocalizedStrings for a repeating element
+// (such as KEYWORD) to the BMEcat 1.2 scalar list for a single language, so a
+// multi-language list does not leak every language's values into 1.2 output.
+func mlSliceToV12(in LocalizedStrings, lang string) []string {
+	return in.All(collapseLangV12(in, lang))
+}
+
+func neutralProductToV12(p *Product, lang string) *bmecat12.Article {
 	a := &bmecat12.Article{
 		Mode:        p.Mode,
 		SupplierAID: p.ID,
 		Details: &bmecat12.ArticleDetails{
-			DescriptionShort:      p.DescriptionShort,
-			DescriptionLong:       p.DescriptionLong,
+			DescriptionShort:      mlToV12(p.DescriptionShort, lang),
+			DescriptionLong:       mlToV12(p.DescriptionLong, lang),
 			EAN:                   p.GTIN,
 			SupplierAltAID:        p.SupplierAltID,
 			ManufacturerAID:       p.ManufacturerID,
 			ManufacturerName:      p.ManufacturerName,
-			ManufacturerTypeDescr: p.ManufacturerTypeDescr,
+			ManufacturerTypeDescr: mlToV12(p.ManufacturerTypeDescr, lang),
 			ERPGroupBuyer:         p.ERPGroupBuyer,
 			ERPGroupSupplier:      p.ERPGroupSupplier,
 			DeliveryTime:          p.DeliveryTime,
-			Keywords:              p.Keywords,
-			Remarks:               p.Remarks,
-			Segments:              p.Segments,
+			Keywords:              mlSliceToV12(p.Keywords, lang),
+			Remarks:               mlToV12(p.Remarks, lang),
+			Segments:              mlSliceToV12(p.Segments, lang),
 		},
 	}
 	for _, b := range p.BuyerIDs {
@@ -214,10 +252,10 @@ func neutralProductToV12(p *Product) *bmecat12.Article {
 		a.OrderDetails = od
 	}
 	for _, f := range p.Features {
-		a.Features = append(a.Features, neutralFeaturesToV12(f))
+		a.Features = append(a.Features, neutralFeaturesToV12(f, lang))
 	}
 	a.PriceDetails = neutralPriceDetailsToV12(p)
-	if mi := neutralMimesToV12(p.Mimes); mi != nil {
+	if mi := neutralMimesToV12(p.Mimes, lang); mi != nil {
 		a.MimeInfo = mi
 	}
 	if udx := neutralUDXToV12(p.UDX); udx != nil {
@@ -244,19 +282,19 @@ func neutralOrderDetailsToV12(p *Product) *bmecat12.ArticleOrderDetails {
 	}
 }
 
-func neutralFeaturesToV12(f *Features) *bmecat12.ArticleFeatures {
+func neutralFeaturesToV12(f *Features, lang string) *bmecat12.ArticleFeatures {
 	if f == nil {
 		return nil
 	}
 	out := &bmecat12.ArticleFeatures{
 		FeatureSystemName: f.SystemName,
 		FeatureGroupID:    f.GroupID,
-		FeatureGroupName:  f.GroupName,
+		FeatureGroupName:  mlToV12(f.GroupName, lang),
 	}
 	for _, ft := range f.Features {
 		out.Features = append(out.Features, &bmecat12.Feature{
-			Name:   ft.Name,
-			Values: ft.Values,
+			Name:   mlToV12(ft.Name, lang),
+			Values: mlSliceToV12(ft.Values, lang),
 			Unit:   ft.Unit,
 		})
 	}
@@ -325,7 +363,7 @@ func neutralPricesToV12(prices []*Price) []*bmecat12.ArticlePrice {
 	return out
 }
 
-func neutralMimesToV12(mimes []*Mime) *bmecat12.MimeInfo {
+func neutralMimesToV12(mimes []*Mime, lang string) *bmecat12.MimeInfo {
 	if len(mimes) == 0 {
 		return nil
 	}
@@ -333,8 +371,8 @@ func neutralMimesToV12(mimes []*Mime) *bmecat12.MimeInfo {
 	for _, m := range mimes {
 		mi.Mimes = append(mi.Mimes, &bmecat12.Mime{
 			Type:    m.Type,
-			Source:  m.Source,
-			Descr:   m.Descr,
+			Source:  mlToV12(m.Source, lang),
+			Descr:   mlToV12(m.Descr, lang),
 			Purpose: m.Purpose,
 			Order:   m.Order,
 		})

--- a/writer_v2005.go
+++ b/writer_v2005.go
@@ -124,9 +124,9 @@ func neutralClassificationSystemToV2005(cs *ClassificationSystem) *bmecat2005.Cl
 	}
 	out := &bmecat2005.ClassificationSystem{
 		Name:        cs.Name,
-		FullName:    cs.FullName,
+		FullName:    localizedToV2005(cs.FullName),
 		Version:     cs.Version,
-		Description: cs.Description,
+		Description: localizedToV2005(cs.Description),
 		Levels:      cs.Levels,
 	}
 	for _, ln := range cs.LevelNames {
@@ -135,6 +135,7 @@ func neutralClassificationSystemToV2005(cs *ClassificationSystem) *bmecat2005.Cl
 		}
 		out.LevelNames = append(out.LevelNames, &bmecat2005.ClassificationSystemLevelName{
 			Level: ln.Level,
+			Lang:  ln.Lang,
 			Value: ln.Name,
 		})
 	}
@@ -145,8 +146,8 @@ func neutralClassificationSystemToV2005(cs *ClassificationSystem) *bmecat2005.Cl
 		out.Groups = append(out.Groups, &bmecat2005.ClassificationGroup{
 			Type:        g.Type,
 			ID:          g.ID,
-			Name:        g.Name,
-			Description: g.Description,
+			Name:        localizedToV2005(g.Name),
+			Description: localizedToV2005(g.Description),
 			ParentID:    g.ParentID,
 		})
 	}
@@ -163,7 +164,7 @@ func neutralHeaderToV2005(h *Header) *bmecat2005.Header {
 			Language:    c.Language,
 			ID:          c.ID,
 			Version:     c.Version,
-			Name:        c.Name,
+			Name:        localizedToV2005(c.Name),
 			Currency:    c.Currency,
 			Territories: c.Territories,
 		}
@@ -183,23 +184,36 @@ func neutralHeaderToV2005(h *Header) *bmecat2005.Header {
 	return out
 }
 
+// localizedToV2005 converts a neutral LocalizedStrings into the bmecat2005 one,
+// preserving variant order and language.
+func localizedToV2005(in LocalizedStrings) bmecat2005.LocalizedStrings {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(bmecat2005.LocalizedStrings, len(in))
+	for i, ls := range in {
+		out[i] = bmecat2005.LocalizedString{Lang: ls.Lang, Value: ls.Value}
+	}
+	return out
+}
+
 func neutralProductToV2005(p *Product) *bmecat2005.Product {
 	prod := &bmecat2005.Product{
 		Mode:        p.Mode,
 		SupplierPID: p.ID,
 		Details: &bmecat2005.ProductDetails{
-			DescriptionShort:      p.DescriptionShort,
-			DescriptionLong:       p.DescriptionLong,
+			DescriptionShort:      localizedToV2005(p.DescriptionShort),
+			DescriptionLong:       localizedToV2005(p.DescriptionLong),
 			SupplierAltPID:        p.SupplierAltID,
 			ManufacturerPID:       p.ManufacturerID,
 			ManufacturerName:      p.ManufacturerName,
-			ManufacturerTypeDescr: p.ManufacturerTypeDescr,
+			ManufacturerTypeDescr: localizedToV2005(p.ManufacturerTypeDescr),
 			ERPGroupBuyer:         p.ERPGroupBuyer,
 			ERPGroupSupplier:      p.ERPGroupSupplier,
 			DeliveryTime:          p.DeliveryTime,
-			Keywords:              p.Keywords,
-			Remarks:               p.Remarks,
-			Segments:              p.Segments,
+			Keywords:              localizedToV2005(p.Keywords),
+			Remarks:               localizedToV2005(p.Remarks),
+			Segments:              localizedToV2005(p.Segments),
 		},
 	}
 	// GTIN maps to INTERNATIONAL_PID (the 2005 replacement for EAN); the reader
@@ -259,12 +273,12 @@ func neutralFeaturesToV2005(f *Features) *bmecat2005.ProductFeatures {
 	out := &bmecat2005.ProductFeatures{
 		FeatureSystemName: f.SystemName,
 		FeatureGroupID:    f.GroupID,
-		FeatureGroupName:  f.GroupName,
+		FeatureGroupName:  localizedToV2005(f.GroupName),
 	}
 	for _, ft := range f.Features {
 		out.Features = append(out.Features, &bmecat2005.Feature{
-			Name:   ft.Name,
-			Values: ft.Values,
+			Name:   localizedToV2005(ft.Name),
+			Values: localizedToV2005(ft.Values),
 			Unit:   ft.Unit,
 		})
 	}
@@ -341,8 +355,8 @@ func neutralMimesToV2005(mimes []*Mime) *bmecat2005.MimeInfo {
 	for _, m := range mimes {
 		mi.Mimes = append(mi.Mimes, &bmecat2005.Mime{
 			Type:    m.Type,
-			Source:  m.Source,
-			Descr:   m.Descr,
+			Source:  localizedToV2005(m.Source),
+			Descr:   localizedToV2005(m.Descr),
 			Purpose: m.Purpose,
 			Order:   m.Order,
 		})


### PR DESCRIPTION
## Problem

On the read path the neutral model and the version-specific structs exposed BMEcat text fields as scalar `string`/`[]string`. BMEcat 2005 types many of these elements as `dtMLSTRING` — one variant per language — so `encoding/xml` collapsed repeated `<… lang="…">` elements onto the scalar (last wins) and discarded the `lang` attribute. A consumer (e.g. a procurement importer with an out-of-band catalog language) could not pick the variant matching a desired language.

## Solution

A `LocalizedStrings` (`[]LocalizedString{Lang, Value}`) type in the neutral `bmecat` package and in `bmecat2005`, used for every `dtMLSTRING` field the packages model. Accessors:

- `Get(lang)` — exact-language match, else the first variant, else `""`
- `Value()` — the first variant
- `All(lang)` — every value for a language (for repeating elements such as `KEYWORD`/`SEGMENT`/`FVALUE`)
- `Set(lang, value)` and the variadic `Localized(values…)` constructor

The version-specific type marshals one element per variant, with a `lang` attribute only when set, and a single empty element when a required field (e.g. `DESCRIPTION_SHORT`) is empty. Single-language catalogs round-trip unchanged (no spurious `lang`).

### Scope

Every modeled `dtMLSTRING` element, verified against the 2005 XSD:

- **Neutral model:** catalog name; product short/long description, manufacturer-type-descr, keywords, remarks, segments; feature group name, feature names, feature values; MIME source + description.
- **`bmecat2005` additionally:** address parts (name/street/city/phone/fax/…), MIME alt, feature descr / value-details / variant values, catalog-group keywords, classification-group synonyms, classification-system level names (`lang` attribute).
- **Stay scalar** (typed `dtSTRING`/codes): `MANUFACTURER_NAME`, `BUYER_NAME`, `SUPPLIER_NAME`, `FUNIT`, the classification-system name identifier, `EMAIL`/`URL`/`PUBLIC_KEY`, units, IDs, currencies.

### BMEcat 1.2

1.2 has no per-element `lang`, so the `bmecat12` structs stay scalar `string`/`[]string`. Reading 1.2 fills each `LocalizedStrings` with a single language-less variant; writing the neutral model to 1.2 emits the variant matching the catalog language (falling back to the first), which is lossy for genuinely multi-language data.

## Breaking change

The affected fields change from `string`/`[]string` to `LocalizedStrings` across `bmecat`, `bmecat12` (reverted to scalar — it had no lang) and `bmecat2005`. Migrate reads such as `p.DescriptionShort` to `p.DescriptionShort.Value()` (or `.Get(lang)` / `.All(lang)`). Warrants a version bump.

## Testing

- Accessor table tests (`Get`/`Value`/`All`/`Set`/`Localized`)
- 2005 multi-language read across the new fields; 2005 write→read round-trip (incl. MIME source, addresses, feature descr/details/variants, catalog-group keywords, synonyms)
- 1.2 collapse behaviour and catalog-language selection on write; attr-free single-language output
- Full suite green under `-race -tags integration`; gofumpt/vet/staticcheck clean

## Follow-ups

- Pre-existing bug discovered: `bmecat2005.ClassificationSystem.LevelNames` is tagged with the plural wrapper while the element `XMLName` is singular, so level names don't unmarshal back (flagged in a test comment).

Closes #46