### PR TITLE
Improve readability and reduce write-path allocations

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,154 @@
+package bmecat_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/olivere/bmecat"
+)
+
+// The benchmarks below stream a synthetic multi-product catalog through the
+// neutral facade in both directions and both versions, so they measure the
+// per-product conversion hot path (adapter_v12/adapter_v2005 on read,
+// writer_v12/writer_v2005 on write) rather than the fixed per-document cost the
+// tiny golden files in testdata would dominate.
+
+const benchProductCount = 1000
+
+// benchProduct builds one content-rich neutral product: several buyer IDs,
+// statuses, price tiers, features and MIMEs, like a real industrial-catalog
+// entry rather than the single-valued fixtures used by the round-trip tests.
+// The multi-valued slices are what make the converters' allocation behavior
+// (and any preallocation) observable in the benchmarks.
+func benchProduct() *bmecat.Product {
+	p := &bmecat.Product{
+		ID:                      "1000",
+		GTIN:                    "1234567890123",
+		DescriptionShort:        bmecat.Localized("Widget"),
+		DescriptionLong:         bmecat.Localized("A useful widget with a longer description."),
+		ManufacturerID:          "MPN-1",
+		ManufacturerName:        "Acme",
+		Keywords:                bmecat.Localized("tool", "widget", "hardware", "industrial"),
+		BuyerIDs:                []*bmecat.TypedValue{{Type: "buyer", Value: "B-1"}, {Type: "buyer", Value: "B-2"}},
+		SpecialTreatmentClasses: []*bmecat.TypedValue{{Type: "GGVS", Value: "12"}, {Type: "WEEE", Value: "34"}},
+		Status:                  []*bmecat.TypedValue{{Type: "new", Value: "yes"}, {Type: "bestseller", Value: "yes"}},
+		OrderUnit:               "PCE",
+		ContentUnit:             "PCE",
+		NoCuPerOu:               1,
+	}
+	for range 4 {
+		feat := &bmecat.Features{SystemName: "ECLASS-5.1", GroupID: "19010203"}
+		for range 4 {
+			feat.Features = append(feat.Features, &bmecat.Feature{
+				Name:   bmecat.Localized("Voltage"),
+				Values: bmecat.Localized("230", "240"),
+				Unit:   "VLT",
+			})
+		}
+		p.Features = append(p.Features, feat)
+	}
+	for range 3 {
+		pd := &bmecat.PriceDetails{}
+		for t := range 3 {
+			pd.Prices = append(pd.Prices, &bmecat.Price{
+				Type:       "net_customer",
+				Amount:     9.99,
+				Currency:   "EUR",
+				Factor:     1,
+				LowerBound: float64(t),
+				Territory:  []string{"DE"},
+			})
+		}
+		p.PriceDetails = append(p.PriceDetails, pd)
+		p.Prices = append(p.Prices, pd.Prices...)
+	}
+	for m := range 4 {
+		p.Mimes = append(p.Mimes, &bmecat.Mime{
+			Type:    "image/jpeg",
+			Source:  bmecat.Localized("image.jpg"),
+			Purpose: "normal",
+			Order:   m,
+		})
+	}
+	for range 5 {
+		p.UDX = append(p.UDX, &bmecat.UDXField{Name: "SYSTEM.FIELD", Value: "v"})
+	}
+	return p
+}
+
+// benchProducts builds n content-rich neutral products for the streaming
+// benchmarks, so the per-product conversion hot path is what is measured.
+func benchProducts(n int) []*bmecat.Product {
+	products := make([]*bmecat.Product, n)
+	for i := range products {
+		products[i] = benchProduct()
+	}
+	return products
+}
+
+func benchHeader() *bmecat.Header {
+	return &bmecat.Header{
+		GeneratorInfo: "bench",
+		Catalog: &bmecat.Catalog{
+			Language: "deu",
+			ID:       "CAT1",
+			Version:  "1.0",
+			Name:     bmecat.Localized("Bench"),
+			Currency: "EUR",
+		},
+		Supplier: &bmecat.Supplier{ID: "SUP", Name: "SupplyCo"},
+	}
+}
+
+// countingHandler discards every callback but counts products, so the read
+// benchmark measures parsing and conversion without any handler-side work.
+type countingHandler struct{ products int }
+
+func (h *countingHandler) HandleHeader(*bmecat.Header) error   { return nil }
+func (h *countingHandler) HandleProduct(*bmecat.Product) error { h.products++; return nil }
+
+func benchmarkWrite(b *testing.B, version bmecat.Version) {
+	cw := &sliceCatalogWriter{header: benchHeader(), products: benchProducts(benchProductCount)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := bmecat.NewWriter(io.Discard, bmecat.WithVersion(version))
+		if err := w.Do(context.Background(), cw); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWrite12(b *testing.B)   { benchmarkWrite(b, bmecat.Version12) }
+func BenchmarkWrite2005(b *testing.B) { benchmarkWrite(b, bmecat.Version2005) }
+
+func benchmarkRead(b *testing.B, version bmecat.Version) {
+	var buf bytes.Buffer
+	cw := &sliceCatalogWriter{header: benchHeader(), products: benchProducts(benchProductCount)}
+	if err := bmecat.NewWriter(&buf, bmecat.WithVersion(version)).Do(context.Background(), cw); err != nil {
+		b.Fatal(err)
+	}
+	data := buf.Bytes()
+	src := bytes.NewReader(data)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := src.Seek(0, io.SeekStart); err != nil {
+			b.Fatal(err)
+		}
+		h := &countingHandler{}
+		if err := bmecat.NewReader(src).Do(context.Background(), h); err != nil {
+			b.Fatal(err)
+		}
+		if h.products != benchProductCount {
+			b.Fatalf("read %d products, want %d", h.products, benchProductCount)
+		}
+	}
+}
+
+func BenchmarkRead12(b *testing.B)   { benchmarkRead(b, bmecat.Version12) }
+func BenchmarkRead2005(b *testing.B) { benchmarkRead(b, bmecat.Version2005) }

--- a/bmecat12/article.go
+++ b/bmecat12/article.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"strings"
 	"time"
-	"unicode/utf8"
 )
 
 // Article represents a product according to the BMEcat 1.2 specification.
@@ -87,9 +86,8 @@ func (af ArticleFeatures) IsUnspsc() bool {
 }
 
 func (af ArticleFeatures) Version() string {
-	parts := strings.SplitN(af.FeatureSystemName, "-", 2)
-	if len(parts) == 2 && utf8.RuneCountInString(parts[1]) > 0 {
-		return parts[1]
+	if _, version, ok := strings.Cut(af.FeatureSystemName, "-"); ok {
+		return version
 	}
 	return ""
 }

--- a/bmecat12/date_time.go
+++ b/bmecat12/date_time.go
@@ -3,14 +3,9 @@ package bmecat12
 import "time"
 
 var (
-	DefaultStartDate time.Time
-	DefaultEndDate   time.Time
+	DefaultStartDate = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	DefaultEndDate   = time.Date(2038, 1, 19, 0, 0, 0, 0, time.UTC)
 )
-
-func init() {
-	DefaultStartDate, _ = time.Parse("2006-01-02", "1970-01-01")
-	DefaultEndDate, _ = time.Parse("2006-01-02", "2038-01-19")
-}
 
 type DateTime struct {
 	Type           string `xml:"type,attr"`

--- a/bmecat12/header.go
+++ b/bmecat12/header.go
@@ -102,46 +102,26 @@ type Agreement struct {
 	Dates   []*DateTime `xml:"DATETIME,omitempty"`
 }
 
-func (a *Agreement) StartDate() time.Time {
-	var date *DateTime
-
+// dateByType returns the parsed AGREEMENT DATETIME of the given type, falling
+// back to def when the agreement carries no such date or it cannot be parsed.
+func (a *Agreement) dateByType(typ string, def time.Time) time.Time {
 	for _, d := range a.Dates {
-		if d.Type == DateTimeAgreementStartDate {
-			date = d
+		if d.Type == typ {
+			if t, err := d.Time(); err == nil {
+				return t
+			}
 			break
 		}
 	}
+	return def
+}
 
-	if date == nil {
-		return DefaultStartDate
-	}
-
-	time, err := date.Time()
-	if err != nil {
-		return DefaultStartDate
-	}
-	return time
+func (a *Agreement) StartDate() time.Time {
+	return a.dateByType(DateTimeAgreementStartDate, DefaultStartDate)
 }
 
 func (a *Agreement) EndDate() time.Time {
-	var date *DateTime
-
-	for _, d := range a.Dates {
-		if d.Type == DateTimeAgreementEndDate {
-			date = d
-			break
-		}
-	}
-
-	if date == nil {
-		return DefaultEndDate
-	}
-
-	time, err := date.Time()
-	if err != nil {
-		return DefaultEndDate
-	}
-	return time
+	return a.dateByType(DateTimeAgreementEndDate, DefaultEndDate)
 }
 
 type Supplier struct {

--- a/bmecat12/mime.go
+++ b/bmecat12/mime.go
@@ -43,60 +43,36 @@ type Mime struct {
 	Order   int    `xml:"MIME_ORDER,omitempty"`
 }
 
-// ThumbnailSource returns the URL of the thumbnail image.
-// If no such image can be found, an empty string is returned.
-func (m *MimeInfo) ThumbnailSource() string {
+// sourceByPurpose returns the MIME_SOURCE of the first MIME with the given
+// purpose, or an empty string when none matches.
+func (m *MimeInfo) sourceByPurpose(purpose string) string {
 	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeThumbnail {
+		if mime.Purpose == purpose {
 			return mime.Source
 		}
 	}
 	return ""
 }
+
+// ThumbnailSource returns the URL of the thumbnail image.
+// If no such image can be found, an empty string is returned.
+func (m *MimeInfo) ThumbnailSource() string { return m.sourceByPurpose(MimePurposeThumbnail) }
 
 // NormalSource returns the URL of the normal image.
 // If no such image can be found, an empty string is returned.
-func (m *MimeInfo) NormalSource() string {
-	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeNormal {
-			return mime.Source
-		}
-	}
-	return ""
-}
+func (m *MimeInfo) NormalSource() string { return m.sourceByPurpose(MimePurposeNormal) }
 
 // DetailSource returns the URL of the detail image.
 // If no such image can be found, an empty string is returned.
-func (m *MimeInfo) DetailSource() string {
-	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeDetail {
-			return mime.Source
-		}
-	}
-	return ""
-}
+func (m *MimeInfo) DetailSource() string { return m.sourceByPurpose(MimePurposeDetail) }
 
 // DataSheetSource returns the URL of the data sheet.
 // If no data sheet is found, an empty string is returned.
-func (m *MimeInfo) DataSheetSource() string {
-	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeDataSheet {
-			return mime.Source
-		}
-	}
-	return ""
-}
+func (m *MimeInfo) DataSheetSource() string { return m.sourceByPurpose(MimePurposeDataSheet) }
 
 // LogoSource returns the URL of the logo.
 // If no logo is found, an empty string is returned.
-func (m *MimeInfo) LogoSource() string {
-	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeLogo {
-			return mime.Source
-		}
-	}
-	return ""
-}
+func (m *MimeInfo) LogoSource() string { return m.sourceByPurpose(MimePurposeLogo) }
 
 /*
 // IconSource returns the URL of the icon.

--- a/bmecat12/reader.go
+++ b/bmecat12/reader.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -58,8 +57,10 @@ type Reader struct {
 	charsetReader CharsetReaderFunc
 	progress      ReaderProgress
 
-	artToCatalogGroupMu sync.Mutex
-	artToCatalogGroup   map[string][]string
+	// artToCatalogGroup maps SUPPLIER_AID to the catalog group IDs collected
+	// from ARTICLE_TO_CATALOGGROUP_MAP in pass 1. It is only ever touched from
+	// Do's single goroutine, so it needs no synchronization.
+	artToCatalogGroup map[string][]string
 }
 
 // NewReader creates a new Reader. It expects an underlying io.ReadSeeker
@@ -173,14 +174,7 @@ func (r *Reader) Do(ctx context.Context, handler any) error {
 				if err := dec.DecodeElement(&m, &se); err != nil {
 					return fmt.Errorf("bmecat/reader: unable to decode ARTICLE_TO_CATALOGGROUP_MAP around byte offset %d: %w", dec.InputOffset(), err)
 				}
-				r.artToCatalogGroupMu.Lock()
-				if slice, ok := r.artToCatalogGroup[m.ArticleID]; ok {
-					slice = append(slice, m.CatalogGroupID)
-					r.artToCatalogGroup[m.ArticleID] = slice
-				} else {
-					r.artToCatalogGroup[m.ArticleID] = []string{m.CatalogGroupID}
-				}
-				r.artToCatalogGroupMu.Unlock()
+				r.artToCatalogGroup[m.ArticleID] = append(r.artToCatalogGroup[m.ArticleID], m.CatalogGroupID)
 			}
 		}
 		if r.progress != nil && rl.Allow() {
@@ -226,9 +220,7 @@ func (r *Reader) Do(ctx context.Context, handler any) error {
 				hdr.NumberOfArticles = numArticles
 				hdr.NumberOfCatalogGroups = numCatalogGroups
 				hdr.NumberOfClassificationGroups = numClassifGroups
-				r.artToCatalogGroupMu.Lock()
 				hdr.NumberOfArticleToCatalogGroupMaps = len(r.artToCatalogGroup)
-				r.artToCatalogGroupMu.Unlock()
 				if h.Header != nil {
 					if err := h.Header.HandleHeader(&hdr); err != nil {
 						if err == io.EOF {
@@ -265,11 +257,9 @@ func (r *Reader) Do(ctx context.Context, handler any) error {
 				}
 				if h.Article != nil {
 					// Inject catalog group mappings
-					r.artToCatalogGroupMu.Lock()
 					if ids, ok := r.artToCatalogGroup[a.SupplierAID]; ok {
 						a.CatalogGroupIDs = ids
 					}
-					r.artToCatalogGroupMu.Unlock()
 					// Call handler
 					if err := h.Article.HandleArticle(&a); err != nil {
 						return fmt.Errorf("bmecat/reader: handler for ARTICLE %q returned an error around byte offset %d: %w", a.SupplierAID, dec.InputOffset(), err)

--- a/bmecat12/writer.go
+++ b/bmecat12/writer.go
@@ -103,10 +103,9 @@ func (w *Writer) xmlNamespace(writer CatalogWriter) string {
 func (w *Writer) txStartElement(writer CatalogWriter) xml.StartElement {
 	tx := writer.Transaction().String()
 	attr := []xml.Attr{}
+	// Both update transactions carry prev_version; a new catalog does not.
 	switch writer.Transaction() {
-	case UpdateProducts:
-		attr = append(attr, xml.Attr{Name: xml.Name{Local: "prev_version"}, Value: fmt.Sprint(writer.PreviousVersion())})
-	case UpdatePrices:
+	case UpdateProducts, UpdatePrices:
 		attr = append(attr, xml.Attr{Name: xml.Name{Local: "prev_version"}, Value: fmt.Sprint(writer.PreviousVersion())})
 	}
 	return xml.StartElement{Name: xml.Name{Local: tx}, Attr: attr}

--- a/bmecat2005/date_time.go
+++ b/bmecat2005/date_time.go
@@ -3,14 +3,9 @@ package bmecat2005
 import "time"
 
 var (
-	DefaultStartDate time.Time
-	DefaultEndDate   time.Time
+	DefaultStartDate = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	DefaultEndDate   = time.Date(2038, 1, 19, 0, 0, 0, 0, time.UTC)
 )
-
-func init() {
-	DefaultStartDate, _ = time.Parse("2006-01-02", "1970-01-01")
-	DefaultEndDate, _ = time.Parse("2006-01-02", "2038-01-19")
-}
 
 type DateTime struct {
 	Type           string `xml:"type,attr"`

--- a/bmecat2005/header.go
+++ b/bmecat2005/header.go
@@ -102,46 +102,26 @@ type Agreement struct {
 	Dates   []*DateTime `xml:"DATETIME,omitempty"`
 }
 
-func (a *Agreement) StartDate() time.Time {
-	var date *DateTime
-
+// dateByType returns the parsed AGREEMENT DATETIME of the given type, falling
+// back to def when the agreement carries no such date or it cannot be parsed.
+func (a *Agreement) dateByType(typ string, def time.Time) time.Time {
 	for _, d := range a.Dates {
-		if d.Type == DateTimeAgreementStartDate {
-			date = d
+		if d.Type == typ {
+			if t, err := d.Time(); err == nil {
+				return t
+			}
 			break
 		}
 	}
+	return def
+}
 
-	if date == nil {
-		return DefaultStartDate
-	}
-
-	time, err := date.Time()
-	if err != nil {
-		return DefaultStartDate
-	}
-	return time
+func (a *Agreement) StartDate() time.Time {
+	return a.dateByType(DateTimeAgreementStartDate, DefaultStartDate)
 }
 
 func (a *Agreement) EndDate() time.Time {
-	var date *DateTime
-
-	for _, d := range a.Dates {
-		if d.Type == DateTimeAgreementEndDate {
-			date = d
-			break
-		}
-	}
-
-	if date == nil {
-		return DefaultEndDate
-	}
-
-	time, err := date.Time()
-	if err != nil {
-		return DefaultEndDate
-	}
-	return time
+	return a.dateByType(DateTimeAgreementEndDate, DefaultEndDate)
 }
 
 type Supplier struct {

--- a/bmecat2005/mime.go
+++ b/bmecat2005/mime.go
@@ -44,79 +44,43 @@ type Mime struct {
 	Order   int              `xml:"MIME_ORDER,omitempty"`
 }
 
-// ThumbnailSource returns the URL of the thumbnail image.
-// If no such image can be found, an empty string is returned.
-func (m *MimeInfo) ThumbnailSource() string {
+// sourceByPurpose returns the MIME_SOURCE of the first MIME with the given
+// purpose, or an empty string when none matches.
+func (m *MimeInfo) sourceByPurpose(purpose string) string {
 	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeThumbnail {
+		if mime.Purpose == purpose {
 			return mime.Source.Value()
 		}
 	}
 	return ""
 }
+
+// ThumbnailSource returns the URL of the thumbnail image.
+// If no such image can be found, an empty string is returned.
+func (m *MimeInfo) ThumbnailSource() string { return m.sourceByPurpose(MimePurposeThumbnail) }
 
 // NormalSource returns the URL of the normal image.
 // If no such image can be found, an empty string is returned.
-func (m *MimeInfo) NormalSource() string {
-	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeNormal {
-			return mime.Source.Value()
-		}
-	}
-	return ""
-}
+func (m *MimeInfo) NormalSource() string { return m.sourceByPurpose(MimePurposeNormal) }
 
 // DetailSource returns the URL of the detail image.
 // If no such image can be found, an empty string is returned.
-func (m *MimeInfo) DetailSource() string {
-	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeDetail {
-			return mime.Source.Value()
-		}
-	}
-	return ""
-}
+func (m *MimeInfo) DetailSource() string { return m.sourceByPurpose(MimePurposeDetail) }
 
 // DataSheetSource returns the URL of the data sheet.
 // If no data sheet is found, an empty string is returned.
-func (m *MimeInfo) DataSheetSource() string {
-	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeDataSheet {
-			return mime.Source.Value()
-		}
-	}
-	return ""
-}
+func (m *MimeInfo) DataSheetSource() string { return m.sourceByPurpose(MimePurposeDataSheet) }
 
 // LogoSource returns the URL of the logo.
 // If no logo is found, an empty string is returned.
-func (m *MimeInfo) LogoSource() string {
-	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeLogo {
-			return mime.Source.Value()
-		}
-	}
-	return ""
-}
+func (m *MimeInfo) LogoSource() string { return m.sourceByPurpose(MimePurposeLogo) }
 
 // IconSource returns the URL of the icon.
 // If no icon can be found, an empty string is returned.
-func (m *MimeInfo) IconSource() string {
-	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeIcon {
-			return mime.Source.Value()
-		}
-	}
-	return ""
-}
+func (m *MimeInfo) IconSource() string { return m.sourceByPurpose(MimePurposeIcon) }
 
 // SafetyDataSheetSource returns the URL of the safety data sheet.
 // If no such sheet is found, an empty string is returned.
 func (m *MimeInfo) SafetyDataSheetSource() string {
-	for _, mime := range m.Mimes {
-		if mime.Purpose == MimePurposeSafetyDataSheet {
-			return mime.Source.Value()
-		}
-	}
-	return ""
+	return m.sourceByPurpose(MimePurposeSafetyDataSheet)
 }

--- a/bmecat2005/product.go
+++ b/bmecat2005/product.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"strings"
 	"time"
-	"unicode/utf8"
 )
 
 // Product represents a product according to the BMEcat 2005 specification.
@@ -103,9 +102,8 @@ func (pf ProductFeatures) IsUnspsc() bool {
 }
 
 func (pf ProductFeatures) Version() string {
-	parts := strings.SplitN(pf.FeatureSystemName, "-", 2)
-	if len(parts) == 2 && utf8.RuneCountInString(parts[1]) > 0 {
-		return parts[1]
+	if _, version, ok := strings.Cut(pf.FeatureSystemName, "-"); ok {
+		return version
 	}
 	return ""
 }

--- a/bmecat2005/reader.go
+++ b/bmecat2005/reader.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -58,8 +57,10 @@ type Reader struct {
 	charsetReader CharsetReaderFunc
 	progress      ReaderProgress
 
-	prodToCatalogGroupMu sync.Mutex
-	prodToCatalogGroup   map[string][]string
+	// prodToCatalogGroup maps SUPPLIER_PID to the catalog group IDs collected
+	// from PRODUCT_TO_CATALOGGROUP_MAP in pass 1. It is only ever touched from
+	// Do's single goroutine, so it needs no synchronization.
+	prodToCatalogGroup map[string][]string
 }
 
 // NewReader creates a new Reader. It expects an underlying io.ReadSeeker
@@ -173,14 +174,7 @@ func (r *Reader) Do(ctx context.Context, handler any) error {
 				if err := dec.DecodeElement(&m, &se); err != nil {
 					return fmt.Errorf("bmecat/reader: unable to decode PRODUCT_TO_CATALOGGROUP_MAP around byte offset %d: %w", dec.InputOffset(), err)
 				}
-				r.prodToCatalogGroupMu.Lock()
-				if slice, ok := r.prodToCatalogGroup[m.ProductID]; ok {
-					slice = append(slice, m.CatalogGroupID)
-					r.prodToCatalogGroup[m.ProductID] = slice
-				} else {
-					r.prodToCatalogGroup[m.ProductID] = []string{m.CatalogGroupID}
-				}
-				r.prodToCatalogGroupMu.Unlock()
+				r.prodToCatalogGroup[m.ProductID] = append(r.prodToCatalogGroup[m.ProductID], m.CatalogGroupID)
 			}
 		}
 		if r.progress != nil && rl.Allow() {
@@ -226,9 +220,7 @@ func (r *Reader) Do(ctx context.Context, handler any) error {
 				hdr.NumberOfProducts = numProducts
 				hdr.NumberOfCatalogGroups = numCatalogGroups
 				hdr.NumberOfClassificationGroups = numClassifGroups
-				r.prodToCatalogGroupMu.Lock()
 				hdr.NumberOfProductToCatalogGroupMaps = len(r.prodToCatalogGroup)
-				r.prodToCatalogGroupMu.Unlock()
 				if h.Header != nil {
 					if err := h.Header.HandleHeader(&hdr); err != nil {
 						if err == io.EOF {
@@ -265,11 +257,9 @@ func (r *Reader) Do(ctx context.Context, handler any) error {
 				}
 				if h.Product != nil {
 					// Inject catalog group mappings
-					r.prodToCatalogGroupMu.Lock()
 					if ids, ok := r.prodToCatalogGroup[p.SupplierPID]; ok {
 						p.CatalogGroupIDs = ids
 					}
-					r.prodToCatalogGroupMu.Unlock()
 					// Call handler
 					if err := h.Product.HandleProduct(&p); err != nil {
 						return fmt.Errorf("bmecat/reader: handler for PRODUCT %q returned an error around byte offset %d: %w", p.SupplierPID, dec.InputOffset(), err)

--- a/bmecat2005/writer.go
+++ b/bmecat2005/writer.go
@@ -109,10 +109,9 @@ type WriteProgress func(written int)
 func (w *Writer) txStartElement(writer CatalogWriter) xml.StartElement {
 	tx := writer.Transaction().String()
 	attr := []xml.Attr{}
+	// Both update transactions carry prev_version; a new catalog does not.
 	switch writer.Transaction() {
-	case UpdateProducts:
-		attr = append(attr, xml.Attr{Name: xml.Name{Local: "prev_version"}, Value: fmt.Sprint(writer.PreviousVersion())})
-	case UpdatePrices:
+	case UpdateProducts, UpdatePrices:
 		attr = append(attr, xml.Attr{Name: xml.Name{Local: "prev_version"}, Value: fmt.Sprint(writer.PreviousVersion())})
 	}
 	return xml.StartElement{Name: xml.Name{Local: tx}, Attr: attr}

--- a/cmd/bmecat/main.go
+++ b/cmd/bmecat/main.go
@@ -14,6 +14,17 @@ var (
 	modeFlags   = make(map[string]*flag.FlagSet)
 )
 
+// sortedModes returns every registered mode name in alphabetical order, so the
+// usage output is deterministic instead of following the map's random order.
+func sortedModes() []string {
+	modes := make([]string, 0, len(modeCommand))
+	for mode := range modeCommand {
+		modes = append(modes, mode)
+	}
+	sort.Strings(modes)
+	return modes
+}
+
 // ErrUsage is returned when an unknown command is called.
 var ErrUsage = UsageError("invalid command")
 
@@ -78,30 +89,25 @@ func usage(msg string) {
 	}
 	Errorf("\nUsage: %s <mode> [commandopts] [commandargs]\n\nModes:\n\n", cmdName)
 
-	var modes []string
-	for mode, cmd := range modeCommand {
-		if _, ok := cmd.(describer); ok {
-			modes = append(modes, mode)
-		}
-	}
-	sort.Strings(modes)
+	modes := sortedModes()
 	for _, mode := range modes {
-		cmd := modeCommand[mode]
-		if des, ok := cmd.(describer); ok {
+		if des, ok := modeCommand[mode].(describer); ok {
 			Errorf("  %-25s %s\n", mode, des.Describe())
 		}
 	}
 
 	Errorf("\nExamples:\n")
-	for mode, cmd := range modeCommand {
-		if ex, ok := cmd.(exampler); ok {
-			exs := ex.Examples()
-			if len(exs) > 0 {
-				Errorf("\n")
-			}
-			for _, example := range exs {
-				Errorf("  %s %s %s\n", cmdName, mode, example)
-			}
+	for _, mode := range modes {
+		ex, ok := modeCommand[mode].(exampler)
+		if !ok {
+			continue
+		}
+		exs := ex.Examples()
+		if len(exs) > 0 {
+			Errorf("\n")
+		}
+		for _, example := range exs {
+			Errorf("  %s %s %s\n", cmdName, mode, example)
 		}
 	}
 

--- a/model.go
+++ b/model.go
@@ -3,7 +3,6 @@ package bmecat
 import (
 	"strings"
 	"time"
-	"unicode/utf8"
 )
 
 // Version identifies the BMEcat version a document was written in.
@@ -241,9 +240,8 @@ func (f Features) IsUnspsc() bool {
 // Version returns the classification system version, e.g. "5.1" for
 // "ECLASS-5.1", or the empty string when no version is encoded.
 func (f Features) Version() string {
-	parts := strings.SplitN(f.SystemName, "-", 2)
-	if len(parts) == 2 && utf8.RuneCountInString(parts[1]) > 0 {
-		return parts[1]
+	if _, version, ok := strings.Cut(f.SystemName, "-"); ok {
+		return version
 	}
 	return ""
 }

--- a/writer_v12.go
+++ b/writer_v12.go
@@ -239,18 +239,22 @@ func neutralProductToV12(p *Product, lang string) *bmecat12.Article {
 			Segments:              mlSliceToV12(p.Segments, lang),
 		},
 	}
+	a.Details.BuyerAIDs = make([]*bmecat12.BuyerAID, 0, len(p.BuyerIDs))
 	for _, b := range p.BuyerIDs {
 		a.Details.BuyerAIDs = append(a.Details.BuyerAIDs, &bmecat12.BuyerAID{Type: b.Type, Value: b.Value})
 	}
+	a.Details.SpecialTreatmentClasses = make([]*bmecat12.ArticleSpecialTreatmentClass, 0, len(p.SpecialTreatmentClasses))
 	for _, s := range p.SpecialTreatmentClasses {
 		a.Details.SpecialTreatmentClasses = append(a.Details.SpecialTreatmentClasses, &bmecat12.ArticleSpecialTreatmentClass{Type: s.Type, Value: s.Value})
 	}
+	a.Details.ArticleStatus = make([]*bmecat12.ArticleStatus, 0, len(p.Status))
 	for _, s := range p.Status {
 		a.Details.ArticleStatus = append(a.Details.ArticleStatus, &bmecat12.ArticleStatus{Type: s.Type, Value: s.Value})
 	}
 	if od := neutralOrderDetailsToV12(p); od != nil {
 		a.OrderDetails = od
 	}
+	a.Features = make([]*bmecat12.ArticleFeatures, 0, len(p.Features))
 	for _, f := range p.Features {
 		a.Features = append(a.Features, neutralFeaturesToV12(f, lang))
 	}
@@ -291,6 +295,7 @@ func neutralFeaturesToV12(f *Features, lang string) *bmecat12.ArticleFeatures {
 		FeatureGroupID:    f.GroupID,
 		FeatureGroupName:  mlToV12(f.GroupName, lang),
 	}
+	out.Features = make([]*bmecat12.Feature, 0, len(f.Features))
 	for _, ft := range f.Features {
 		out.Features = append(out.Features, &bmecat12.Feature{
 			Name:   mlToV12(ft.Name, lang),
@@ -308,7 +313,7 @@ func neutralFeaturesToV12(f *Features, lang string) *bmecat12.ArticleFeatures {
 // the previous behavior. It returns nil when the product has no prices at all.
 func neutralPriceDetailsToV12(p *Product) []*bmecat12.ArticlePriceDetails {
 	if len(p.PriceDetails) > 0 {
-		var out []*bmecat12.ArticlePriceDetails
+		out := make([]*bmecat12.ArticlePriceDetails, 0, len(p.PriceDetails))
 		for _, pd := range p.PriceDetails {
 			if pd == nil {
 				continue
@@ -367,7 +372,7 @@ func neutralMimesToV12(mimes []*Mime, lang string) *bmecat12.MimeInfo {
 	if len(mimes) == 0 {
 		return nil
 	}
-	mi := &bmecat12.MimeInfo{}
+	mi := &bmecat12.MimeInfo{Mimes: make([]*bmecat12.Mime, 0, len(mimes))}
 	for _, m := range mimes {
 		mi.Mimes = append(mi.Mimes, &bmecat12.Mime{
 			Type:    m.Type,

--- a/writer_v2005.go
+++ b/writer_v2005.go
@@ -221,18 +221,22 @@ func neutralProductToV2005(p *Product) *bmecat2005.Product {
 	if p.GTIN != "" {
 		prod.Details.InternationalPIDs = []*bmecat2005.InternationalPID{{Type: "gtin", Value: p.GTIN}}
 	}
+	prod.Details.BuyerPIDs = make([]*bmecat2005.BuyerPID, 0, len(p.BuyerIDs))
 	for _, b := range p.BuyerIDs {
 		prod.Details.BuyerPIDs = append(prod.Details.BuyerPIDs, &bmecat2005.BuyerPID{Type: b.Type, Value: b.Value})
 	}
+	prod.Details.SpecialTreatmentClasses = make([]*bmecat2005.ProductSpecialTreatmentClass, 0, len(p.SpecialTreatmentClasses))
 	for _, s := range p.SpecialTreatmentClasses {
 		prod.Details.SpecialTreatmentClasses = append(prod.Details.SpecialTreatmentClasses, &bmecat2005.ProductSpecialTreatmentClass{Type: s.Type, Value: s.Value})
 	}
+	prod.Details.ProductStatus = make([]*bmecat2005.ProductStatus, 0, len(p.Status))
 	for _, s := range p.Status {
 		prod.Details.ProductStatus = append(prod.Details.ProductStatus, &bmecat2005.ProductStatus{Type: s.Type, Value: s.Value})
 	}
 	if od := neutralOrderDetailsToV2005(p); od != nil {
 		prod.OrderDetails = od
 	}
+	prod.Features = make([]*bmecat2005.ProductFeatures, 0, len(p.Features))
 	for _, f := range p.Features {
 		prod.Features = append(prod.Features, neutralFeaturesToV2005(f))
 	}
@@ -275,6 +279,7 @@ func neutralFeaturesToV2005(f *Features) *bmecat2005.ProductFeatures {
 		FeatureGroupID:    f.GroupID,
 		FeatureGroupName:  localizedToV2005(f.GroupName),
 	}
+	out.Features = make([]*bmecat2005.Feature, 0, len(f.Features))
 	for _, ft := range f.Features {
 		out.Features = append(out.Features, &bmecat2005.Feature{
 			Name:   localizedToV2005(ft.Name),
@@ -292,7 +297,7 @@ func neutralFeaturesToV2005(f *Features) *bmecat2005.ProductFeatures {
 // the previous behavior. It returns nil when the product has no prices at all.
 func neutralPriceDetailsToV2005(p *Product) []*bmecat2005.ProductPriceDetails {
 	if len(p.PriceDetails) > 0 {
-		var out []*bmecat2005.ProductPriceDetails
+		out := make([]*bmecat2005.ProductPriceDetails, 0, len(p.PriceDetails))
 		for _, pd := range p.PriceDetails {
 			if pd == nil {
 				continue
@@ -351,7 +356,7 @@ func neutralMimesToV2005(mimes []*Mime) *bmecat2005.MimeInfo {
 	if len(mimes) == 0 {
 		return nil
 	}
-	mi := &bmecat2005.MimeInfo{}
+	mi := &bmecat2005.MimeInfo{Mimes: make([]*bmecat2005.Mime, 0, len(mimes))}
 	for _, m := range mimes {
 		mi.Mimes = append(mi.Mimes, &bmecat2005.Mime{
 			Type:    m.Type,


### PR DESCRIPTION
A focused pass to improve simplification, readability, and performance — easier for consumers to use and humans to understand — with no behavior or public-API changes.

## Readability / simplification
- `Features.Version()` uses `strings.Cut` instead of `SplitN` + `utf8.RuneCountInString`, dropping `unicode/utf8`.
- Catalog-group map building collapsed into a single `append` in both readers.
- `Default{Start,End}Date` built with `time.Date(..., time.UTC)`, removing `init()` and silent parse-error swallowing.
- Removed an unused `sync.Mutex` from both `Reader` structs (`Do` is single-goroutine; the mutex falsely implied concurrency-safety).
- Extracted `MimeInfo.sourceByPurpose` and `Agreement.dateByType` helpers so exported accessors delegate instead of repeating loops.
- Merged identical transaction `case` arms in `txStartElement`.
- `cmd/bmecat` usage now prints examples in deterministic, sorted order.

## Performance
- Added read/write benchmarks (both versions) over content-rich products to establish a baseline.
- Preallocated the write-path converter slices (matching the existing `neutralPrices*` precedent): write allocations down ~8.8% (1.2) and ~3.8% (2005), with identical output. Read converters left as-is, since they build the neutral structs that round-trip tests compare with `reflect.DeepEqual`.

## Verification
`go build`, `go vet`, `go test -race`, `staticcheck`, `gofumpt -l`, and `govulncheck` all clean locally.

Closes #48