### PR TITLE
Add benchmark tooling and document it in the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ debug.test
 /bmecat
 /data
 /vendor
+
+# Benchmark result files (make bench-save)
+/bench.txt
+/base.txt
+/new.txt

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@
 # `go run` to avoid pulling all of gopls into the module graph.
 MODERNIZE = golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest
 
+# Benchmark knobs (override on the command line, e.g. `make bench BENCH=Write`).
+# BENCHCOUNT samples each benchmark so benchstat has something to compare.
+BENCH ?= .
+BENCHCOUNT ?= 6
+BENCHFILE ?= bench.txt
+
 .PHONY: default
 default: build
 
@@ -14,6 +20,20 @@ build:
 .PHONY: test
 test:
 	go test -race -tags integration ./...
+
+.PHONY: bench
+bench:
+	go test -run '^$$' -bench '$(BENCH)' -benchmem -count=$(BENCHCOUNT) ./...
+
+# Save benchmark results to BENCHFILE (default bench.txt) for benchstat.
+.PHONY: bench-save
+bench-save:
+	go test -run '^$$' -bench '$(BENCH)' -benchmem -count=$(BENCHCOUNT) ./... | tee $(BENCHFILE)
+
+# Compare two saved runs: make benchstat OLD=base.txt NEW=bench.txt
+.PHONY: benchstat
+benchstat:
+	go tool benchstat $(OLD) $(NEW)
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ This replaced the former scalar fields: update reads such as `p.DescriptionShort
 to `p.DescriptionShort.Value()` (or `.Get(lang)` / `.All(lang)`).
 Prices come both flattened (`Product.Prices`) and grouped by their
 `ARTICLE_PRICE_DETAILS` / `PRODUCT_PRICE_DETAILS` wrapper with validity dates
-(`Product.PriceDetails`), so you can pick the currently-valid block or spot a
-price calendar. Runnable examples are in the
+(`Product.PriceDetails`). Helpers pick the block valid at a time with
+`p.CurrentPriceDetails(at)` (or `p.ValidPriceDetails(at)` to spot a price
+calendar of overlapping windows) and select a quantity tier within a block with
+`pd.PriceFor(quantity, priceType)`. Runnable examples are in the
 [package documentation](https://pkg.go.dev/github.com/olivere/bmecat#pkg-examples).
 
 To gate on the document-level transaction — for example to accept only full
@@ -227,6 +229,22 @@ covers those; version-specific fidelity needs the version packages below. The
 neutral writer also does not emit catalog-group mappings (neither version writer
 does).
 
+To emit a `CLASSIFICATION_SYSTEM` (e.g. an eCl@ss or supplier classification
+tree) ahead of the product stream, pass it as configuration with
+`WithClassificationSystem`. Because it is bounded and known up front, it is given
+once rather than streamed; it is written only for a `T_NEW_CATALOG` transaction
+and omitted when blank:
+
+```go
+w := bmecat.NewWriter(out,
+	bmecat.WithVersion(bmecat.Version2005),
+	bmecat.WithClassificationSystem(&bmecat.ClassificationSystem{
+		Name:   "ECLASS-5.1",
+		Groups: groups, // []*bmecat.ClassificationGroup
+	}),
+)
+```
+
 ### Version-specific writing
 
 For full, version-specific fidelity, implement the `CatalogWriter` interface of
@@ -287,8 +305,42 @@ make fmt         # format the code with gofumpt
 make lint        # check formatting and run go vet
 make vulncheck   # scan for known vulnerabilities
 make modernize   # apply modern Go idioms
+make bench       # run the benchmarks
 make check       # lint + test + vulncheck
 ```
+
+### Benchmarks
+
+The package ships read and write benchmarks for both BMEcat versions, streaming
+a content-rich catalog through the neutral facade so the per-product conversion
+path is what is measured. Run them with:
+
+```sh
+make bench                       # all benchmarks, six samples each
+make bench BENCH=Write           # only benchmarks matching "Write"
+make bench BENCHCOUNT=10         # more samples for a tighter estimate
+```
+
+To measure a change against a baseline, save a run before and after, then
+compare them with [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat)
+(managed as a Go tool dependency, so no separate install is needed):
+
+```sh
+# 1. Baseline: stash your change and record the current numbers.
+git stash
+make bench-save BENCHFILE=base.txt
+git stash pop
+
+# 2. Your change: record the new numbers.
+make bench-save BENCHFILE=new.txt
+
+# 3. Compare. benchstat reports the delta and whether it is significant.
+make benchstat OLD=base.txt NEW=new.txt
+```
+
+benchstat needs at least six samples per benchmark for a confidence interval,
+which is why `BENCHCOUNT` defaults to six. A `~` in the output means the change
+was not statistically significant.
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,10 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
+	github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/perf v0.0.0-20260615155930-9e4b9ddef5b6 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260617140237-9b6dc03d9327 // indirect
@@ -21,6 +23,7 @@ require (
 )
 
 tool (
+	golang.org/x/perf/cmd/benchstat
 	golang.org/x/vuln/cmd/govulncheck
 	honnef.co/go/tools/cmd/staticcheck
 	mvdan.cc/gofumpt

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
+github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/go-quicktest/qt v1.102.0 h1:HSQxCeh5YZH3EL3W39ixjtyaEhcWSXQHtHnMBzSs474=
 github.com/go-quicktest/qt v1.102.0/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/google/go-cmdtest v0.4.1-0.20220921163831-55ab3332a786 h1:rcv+Ippz6RAtvaGgKxc+8FQIpxHgsF+HBzPyYL2cyVU=
@@ -18,6 +20,8 @@ golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz
 golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+golang.org/x/perf v0.0.0-20260615155930-9e4b9ddef5b6 h1:YTGOochus7nQXtT5KnsVfJ3/1yslyOyP3m9vMG1qMuQ=
+golang.org/x/perf v0.0.0-20260615155930-9e4b9ddef5b6/go.mod h1:FisaKCtzcRx02gCop3DILSnoD7CMnqwmde2yVxo4meM=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=


### PR DESCRIPTION
Adds Makefile support for running benchmarks and comparing against a baseline, and fills a couple of documentation gaps from recent feature PRs.

## Tooling
- `make bench` — run all benchmarks (six samples each; override with `BENCH=` / `BENCHCOUNT=`).
- `make bench-save BENCHFILE=…` — save a run for comparison.
- `make benchstat OLD=… NEW=…` — compare two runs with [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat).
- `benchstat` is now a `go.mod` tool dependency (pinned), consistent with gofumpt/staticcheck/govulncheck. (`modernize` deliberately stays ad-hoc: it lives in a gopls `internal/` package, so pinning it would pull in the gopls module and bump the module's Go version.)
- Benchmark result files are gitignored.

## README
- New "Benchmarks" subsection under Development: `make bench` and the benchstat baseline workflow.
- Document the `WithClassificationSystem` writer option (from #41), previously undocumented.
- Name the price-block helpers `CurrentPriceDetails`, `ValidPriceDetails`, `PriceFor` (from #45).

## Verification
`go build`, `go vet`, `go test -race`, `staticcheck`, `gofumpt -l`, `govulncheck`, and `go mod verify` all clean locally.