### PR TITLE
Resolve 2005 GTIN from typed INTERNATIONAL_PID

### DIFF
--- a/adapter_test.go
+++ b/adapter_test.go
@@ -381,3 +381,68 @@ func TestNeutralProductOrderAndDetailFields(t *testing.T) {
 		})
 	}
 }
+
+// TestNeutralGTINFromV2005 verifies that the 2005 adapter resolves Product.GTIN
+// from the INTERNATIONAL_PID whose type is gtin/ean, rather than blindly taking
+// the first PID. See issue #51.
+func TestNeutralGTINFromV2005(t *testing.T) {
+	doc := func(pids, ean string) string {
+		return `<?xml version="1.0" encoding="UTF-8"?>
+<BMECAT version="2005" xmlns="http://www.bmecat.org/bmecat/2005">
+  <HEADER><CATALOG><LANGUAGE>eng</LANGUAGE><CATALOG_ID>C</CATALOG_ID><CATALOG_VERSION>1</CATALOG_VERSION></CATALOG></HEADER>
+  <T_NEW_CATALOG>
+    <PRODUCT>
+      <SUPPLIER_PID>P1</SUPPLIER_PID>
+      <PRODUCT_DETAILS>
+        <DESCRIPTION_SHORT>Widget</DESCRIPTION_SHORT>
+        ` + pids + ean + `
+      </PRODUCT_DETAILS>
+    </PRODUCT>
+  </T_NEW_CATALOG>
+</BMECAT>`
+	}
+	for _, tt := range []struct {
+		name string
+		pids string
+		ean  string
+		want string
+	}{
+		{
+			name: "typed gtin preceded by non-gtin PID",
+			pids: `<INTERNATIONAL_PID type="supplier_specific">ACME-001</INTERNATIONAL_PID>
+        <INTERNATIONAL_PID type="gtin">4006381333931</INTERNATIONAL_PID>`,
+			want: "4006381333931",
+		},
+		{
+			name: "typed ean preferred over leading non-gtin PID",
+			pids: `<INTERNATIONAL_PID type="supplier_specific">ACME-001</INTERNATIONAL_PID>
+        <INTERNATIONAL_PID type="EAN">4006381333931</INTERNATIONAL_PID>`,
+			want: "4006381333931",
+		},
+		{
+			name: "untyped PID falls back to first non-empty",
+			pids: `<INTERNATIONAL_PID>4006381333931</INTERNATIONAL_PID>`,
+			want: "4006381333931",
+		},
+		{
+			name: "no typed gtin/ean falls back to first PID",
+			pids: `<INTERNATIONAL_PID type="supplier_specific">ACME-001</INTERNATIONAL_PID>`,
+			want: "ACME-001",
+		},
+		{
+			name: "legacy EAN element when no PID present",
+			ean:  `<EAN>4006381333931</EAN>`,
+			want: "4006381333931",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := read(t, doc(tt.pids, tt.ean))
+			if want, have := 1, len(c.products); want != have {
+				t.Fatalf("want %d product(s), have %d", want, have)
+			}
+			if want, have := tt.want, c.products[0].GTIN; want != have {
+				t.Errorf("GTIN = %q, want %q", have, want)
+			}
+		})
+	}
+}

--- a/adapter_v2005.go
+++ b/adapter_v2005.go
@@ -1,6 +1,7 @@
 package bmecat
 
 import (
+	"strings"
 	"time"
 
 	"github.com/olivere/bmecat/bmecat2005"
@@ -274,13 +275,27 @@ func taxFromV2005Price(pr *bmecat2005.ProductPrice) *float64 {
 	return nil
 }
 
-// gtinFromV2005 returns the canonical GTIN/EAN for a 2005 product: the first
-// INTERNATIONAL_PID value, falling back to the legacy EAN element.
+// gtinFromV2005 returns the canonical GTIN/EAN for a 2005 product. It prefers
+// an INTERNATIONAL_PID explicitly typed gtin or ean, then falls back to the
+// first non-empty PID of any type (an untyped PID is almost always the GTIN),
+// and finally to the legacy EAN element. This stops a leading non-GTIN PID
+// (e.g. type="supplier_specific") from shadowing a correctly-typed one.
 func gtinFromV2005(d *bmecat2005.ProductDetails) string {
+	var first string
 	for _, pid := range d.InternationalPIDs {
-		if pid != nil && pid.Value != "" {
+		if pid == nil || pid.Value == "" {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(pid.Type)) {
+		case "gtin", "ean":
 			return pid.Value
 		}
+		if first == "" {
+			first = pid.Value
+		}
+	}
+	if first != "" {
+		return first
 	}
 	return d.EAN
 }

--- a/model.go
+++ b/model.go
@@ -127,8 +127,9 @@ type Product struct {
 	// Mode is the product's transaction mode ("new", "update" or "delete").
 	// It is typically only set in T_UPDATE_PRODUCTS catalogs.
 	Mode string
-	// GTIN is the global trade item number: EAN (1.2) or the first
-	// INTERNATIONAL_PID (2005). See GTIN handling in the package docs.
+	// GTIN is the global trade item number: EAN (1.2) or the gtin/ean-typed
+	// INTERNATIONAL_PID (2005), falling back to the first PID or legacy EAN.
+	// See GTIN handling in the package docs.
 	GTIN string
 
 	// DescriptionShort and DescriptionLong are DESCRIPTION_SHORT /


### PR DESCRIPTION
## Summary

For BMEcat 2005, `Product.GTIN` was resolved from the **first** `INTERNATIONAL_PID` regardless of its `type` attribute, so a leading non-GTIN identifier (e.g. `type="supplier_specific"`) shadowed a correctly-typed GTIN.

`gtinFromV2005` now:

1. Prefers the first `INTERNATIONAL_PID` typed `gtin` or `ean` (case-insensitive, trimmed).
2. Falls back to the first non-empty PID of any type — an untyped PID is almost always the GTIN, preserving today's behaviour.
3. Falls back to the legacy `EAN` element.

BMEcat 1.2 is unaffected (single `EAN` element).

## Tests

Added `TestNeutralGTINFromV2005` covering typed-gtin-after-non-gtin, typed EAN, untyped fallback, no-typed-gtin fallback, and legacy `EAN`. `go build`, `go vet`, and the full suite are green.

Closes #51