### PR TITLE
Preserve 2005 INTERNATIONAL_PID list on the neutral model

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ func main() {
 ```
 
 The neutral model exposes the fields 1.2 and 2005 share; in particular
-`Product.GTIN` unifies the 1.2 `EAN` and 2005 `INTERNATIONAL_PID` elements.
+`Product.GTIN` unifies the 1.2 `EAN` and 2005 `INTERNATIONAL_PID` elements. For
+2005 documents with more than one `INTERNATIONAL_PID`, `Product.PIDs` preserves
+every typed identifier so a read-modify-write keeps them all.
 
 BMEcat 2005 lets many text elements repeat once per language (the spec's
 `dtMLSTRING` type). Those fields are exposed as `LocalizedStrings`, preserving

--- a/adapter_v2005.go
+++ b/adapter_v2005.go
@@ -139,6 +139,11 @@ func convertV2005Product(p *bmecat2005.Product) *Product {
 	}
 	if d := p.Details; d != nil {
 		out.GTIN = gtinFromV2005(d)
+		for _, pid := range d.InternationalPIDs {
+			if pid != nil {
+				out.PIDs = append(out.PIDs, &TypedValue{Type: pid.Type, Value: pid.Value})
+			}
+		}
 		out.DescriptionShort = localizedFromV2005(d.DescriptionShort)
 		out.DescriptionLong = localizedFromV2005(d.DescriptionLong)
 		out.SupplierAltID = d.SupplierAltPID

--- a/doc.go
+++ b/doc.go
@@ -21,7 +21,9 @@ and ingests 1.2 and 2005 catalogs through the same code path:
 
 The neutral model exposes the fields the two versions have in common. In
 particular [Product.GTIN] unifies the 1.2 EAN element and the 2005
-INTERNATIONAL_PID element behind a single accessor.
+INTERNATIONAL_PID element behind a single accessor. For 2005 documents that
+carry more than one INTERNATIONAL_PID, [Product.PIDs] preserves every typed
+identifier so a read-modify-write keeps them all.
 
 BMEcat 2005 lets many text elements repeat once per language (the spec's
 dtMLSTRING type). Those neutral fields are [LocalizedStrings], keeping every

--- a/model.go
+++ b/model.go
@@ -131,6 +131,15 @@ type Product struct {
 	// INTERNATIONAL_PID (2005), falling back to the first PID or legacy EAN.
 	// See GTIN handling in the package docs.
 	GTIN string
+	// PIDs holds every INTERNATIONAL_PID (2005) with its type attribute, in
+	// document order. It is populated only for BMEcat 2005; 1.2 has a single,
+	// untyped EAN element exposed through GTIN alone, so PIDs is nil there.
+	// GTIN remains the convenience accessor for the gtin/ean-typed value.
+	//
+	// On the 2005 write path PIDs takes precedence: when non-empty it is
+	// emitted verbatim and GTIN is ignored; otherwise a single gtin-typed
+	// INTERNATIONAL_PID is written from GTIN.
+	PIDs []*TypedValue
 
 	// DescriptionShort and DescriptionLong are DESCRIPTION_SHORT /
 	// DESCRIPTION_LONG. They hold every language variant the source document

--- a/reader_test.go
+++ b/reader_test.go
@@ -193,6 +193,12 @@ func TestReadEquivalence(t *testing.T) {
 		t.Errorf("neutral headers differ:\n 1.2: %+v\n2005: %+v", c12.header, c2005.header)
 	}
 
+	// PIDs is 2005-only (1.2 has a single untyped EAN exposed through GTIN);
+	// clear it so the rest of the neutral product can be compared. Both versions
+	// still resolve the same GTIN.
+	for _, p := range c2005.products {
+		p.PIDs = nil
+	}
 	if !reflect.DeepEqual(c12.products, c2005.products) {
 		t.Errorf("neutral products differ:\n 1.2: %+v\n2005: %+v", c12.products[0], c2005.products[0])
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -159,6 +159,11 @@ func TestWriteReadRoundTrip(t *testing.T) {
 			if len(c.products) != 1 {
 				t.Fatalf("want one product, have %d", len(c.products))
 			}
+			// PIDs is version-specific: 2005 reads GTIN back as a gtin-typed
+			// INTERNATIONAL_PID, 1.2 has no typed PID. Normalise before comparing
+			// the shared product; multi-PID round trips are covered by
+			// TestWritePIDs.
+			c.products[0].PIDs = nil
 			if !reflect.DeepEqual(product, c.products[0]) {
 				t.Errorf("product round trip mismatch:\nwant %+v\nhave %+v", product, c.products[0])
 			}
@@ -242,6 +247,60 @@ func TestWriteQuantityMax(t *testing.T) {
 				t.Errorf("want QuantityMax %v, have %v", tt.want, have)
 			}
 		})
+	}
+}
+
+// TestWritePIDs covers the 2005 INTERNATIONAL_PID round trip (issue #53): a
+// product carrying several typed PIDs survives write→read with every PID and
+// its type preserved in order, and GTIN still resolves to the gtin-typed value.
+func TestWritePIDs(t *testing.T) {
+	pids := []*bmecat.TypedValue{
+		{Type: "supplier_specific", Value: "ACME-001"},
+		{Type: "gtin", Value: "4006381333931"},
+		{Type: "upc", Value: "012345678905"},
+	}
+	p := &bmecat.Product{ID: "1", OrderUnit: "PCE", PIDs: pids}
+	cw := &sliceCatalogWriter{products: []*bmecat.Product{p}}
+
+	var buf bytes.Buffer
+	if err := bmecat.NewWriter(&buf, bmecat.WithVersion(bmecat.Version2005)).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+
+	c := read(t, buf.String())
+	if len(c.products) != 1 {
+		t.Fatalf("want one product, have %d", len(c.products))
+	}
+	if !reflect.DeepEqual(pids, c.products[0].PIDs) {
+		t.Errorf("PIDs round trip mismatch:\nwant %+v\nhave %+v", pids, c.products[0].PIDs)
+	}
+	if want, have := "4006381333931", c.products[0].GTIN; want != have {
+		t.Errorf("GTIN = %q, want %q", have, want)
+	}
+}
+
+// TestWritePIDsFallback confirms that a product with no PIDs but a GTIN still
+// writes a single gtin-typed INTERNATIONAL_PID, which reads back as both the
+// GTIN and a one-element PIDs slice.
+func TestWritePIDsFallback(t *testing.T) {
+	p := &bmecat.Product{ID: "1", OrderUnit: "PCE", GTIN: "4006381333931"}
+	cw := &sliceCatalogWriter{products: []*bmecat.Product{p}}
+
+	var buf bytes.Buffer
+	if err := bmecat.NewWriter(&buf, bmecat.WithVersion(bmecat.Version2005)).Do(context.Background(), cw); err != nil {
+		t.Fatal(err)
+	}
+
+	c := read(t, buf.String())
+	if len(c.products) != 1 {
+		t.Fatalf("want one product, have %d", len(c.products))
+	}
+	want := []*bmecat.TypedValue{{Type: "gtin", Value: "4006381333931"}}
+	if !reflect.DeepEqual(want, c.products[0].PIDs) {
+		t.Errorf("PIDs = %+v, want %+v", c.products[0].PIDs, want)
+	}
+	if have := c.products[0].GTIN; have != "4006381333931" {
+		t.Errorf("GTIN = %q, want %q", have, "4006381333931")
 	}
 }
 
@@ -330,6 +389,11 @@ func TestWriteFuncRoundTrip(t *testing.T) {
 			if len(c.products) != 1 {
 				t.Fatalf("want one product, have %d", len(c.products))
 			}
+			// PIDs is version-specific: 2005 reads GTIN back as a gtin-typed
+			// INTERNATIONAL_PID, 1.2 has no typed PID. Normalise before comparing
+			// the shared product; multi-PID round trips are covered by
+			// TestWritePIDs.
+			c.products[0].PIDs = nil
 			if !reflect.DeepEqual(product, c.products[0]) {
 				t.Errorf("product round trip mismatch:\nwant %+v\nhave %+v", product, c.products[0])
 			}

--- a/writer_v2005.go
+++ b/writer_v2005.go
@@ -216,9 +216,18 @@ func neutralProductToV2005(p *Product) *bmecat2005.Product {
 			Segments:              localizedToV2005(p.Segments),
 		},
 	}
-	// GTIN maps to INTERNATIONAL_PID (the 2005 replacement for EAN); the reader
-	// reads it back from the first INTERNATIONAL_PID.
-	if p.GTIN != "" {
+	// INTERNATIONAL_PID (the 2005 replacement for EAN). PIDs takes precedence
+	// when set so a read-modify-write preserves every typed identifier;
+	// otherwise emit a single gtin-typed PID from the GTIN convenience field.
+	if len(p.PIDs) > 0 {
+		pids := make([]*bmecat2005.InternationalPID, 0, len(p.PIDs))
+		for _, pid := range p.PIDs {
+			if pid != nil {
+				pids = append(pids, &bmecat2005.InternationalPID{Type: pid.Type, Value: pid.Value})
+			}
+		}
+		prod.Details.InternationalPIDs = pids
+	} else if p.GTIN != "" {
 		prod.Details.InternationalPIDs = []*bmecat2005.InternationalPID{{Type: "gtin", Value: p.GTIN}}
 	}
 	prod.Details.BuyerPIDs = make([]*bmecat2005.BuyerPID, 0, len(p.BuyerIDs))


### PR DESCRIPTION
## Summary

The neutral model exposed a single unified `Product.GTIN`, and the 2005 writer always emitted exactly one `INTERNATIONAL_PID type="gtin"` from it. A read-modify-write of a 2005 document therefore dropped any other `INTERNATIONAL_PID`s the source carried (`upc`, `ean`, `supplier_specific`, …).

This adds a typed multi-PID field so 2005 identifiers round-trip losslessly:

- **`Product.PIDs []*TypedValue`** holds every `INTERNATIONAL_PID` with its type, in document order. It is populated only for 2005 (1.2 has a single untyped `EAN`, still exposed through `GTIN`). `GTIN` stays the convenience accessor for the gtin/ean-typed value.
- **Read** (`adapter_v2005.go`): populate `PIDs` from `INTERNATIONAL_PID`; `GTIN` resolution is unchanged (#51).
- **Write** (`writer_v2005.go`): `PIDs` takes precedence — when non-empty it is emitted verbatim; otherwise a single gtin-typed `INTERNATIONAL_PID` is written from `GTIN` (preserves prior behaviour).

BMEcat 1.2 is unaffected (single `EAN` element via `GTIN`).

## Tests

- `TestWritePIDs` — three typed PIDs survive write→read in order; `GTIN` still resolves to the gtin-typed value.
- `TestWritePIDsFallback` — a product with only `GTIN` writes a single gtin PID that reads back as both `GTIN` and a one-element `PIDs`.
- The version-asymmetric `PIDs` field is normalised in the existing equality tests (`TestReadEquivalence`, `TestWriteReadRoundTrip`, `TestWriteFuncRoundTrip`), the same pattern already used for `QuantityMax`.

`go build`, `go vet`, full `go test`, `gofumpt`, `staticcheck`, and `modernize` are all clean.

Closes #53